### PR TITLE
Migrate React blog to Next.js

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,12 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import Link from "next/link";
+import Navbar from "../components/Navbar";
+import CookieConsentBanner from "../components/CookieConsentBanner";
+import AnalyticsRouteChangeTracker from "../components/AnalyticsRouteChangeTracker";
+import { SiteConfigProvider } from "../contexts/SiteConfigContext";
+import { CookieConsentProvider } from "../contexts/CookieConsentContext";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -24,10 +30,28 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
-      >
-        {children}
+      <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
+        <SiteConfigProvider>
+          <CookieConsentProvider>
+            <div className="flex flex-col min-h-screen">
+              <Navbar />
+              <main className="flex-grow bg-gray-100 py-8">
+                <AnalyticsRouteChangeTracker />
+                {children}
+              </main>
+              <CookieConsentBanner />
+              <footer className="bg-primary-800 text-primary-100 text-center p-6 shadow-inner">
+                <p>&copy; {new Date().getFullYear()} React Markdown Blog. All rights reserved.</p>
+                <p className="text-sm mt-1">
+                  Powered by React, Tailwind CSS, and your Markdown! |{' '}
+                  <Link href="/page/privacy-policy" className="underline hover:text-primary-300">
+                    Informativa Privacy e Cookie Policy
+                  </Link>
+                </p>
+              </footer>
+            </div>
+          </CookieConsentProvider>
+        </SiteConfigProvider>
       </body>
     </html>
   );

--- a/app/page/[slug]/page.tsx
+++ b/app/page/[slug]/page.tsx
@@ -1,0 +1,106 @@
+
+"use client";
+
+import React, { useEffect, useState } from 'react';
+import { useParams } from 'next/navigation';
+import Link from 'next/link';
+import { Page } from '../../../types';
+import MarkdownRenderer from '../../../components/MarkdownRenderer';
+import { parseFrontMatter } from '../../../utils/frontMatterParser';
+
+const GenericPage: React.FC = () => {
+  const params = useParams();
+  const slug = typeof params?.slug === 'string' ? params.slug : undefined;
+  const [page, setPage] = useState<Page | undefined>(undefined);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!slug) {
+      setError('Page slug is missing.');
+      setIsLoading(false);
+      return;
+    }
+
+    setIsLoading(true);
+    setError(null);
+    setPage(undefined);
+
+    fetch(`/content/pages/${slug}.md`)
+      .then(response => {
+        if (!response.ok) {
+          throw new Error(`Failed to fetch page content: ${response.statusText} (status: ${response.status})`);
+        }
+        return response.text();
+      })
+      .then(rawContent => {
+        const { frontMatter, content: markdownBody } = parseFrontMatter(rawContent); // frontMatter is Record<string, any>
+        
+        const pageData: Page = {
+          slug: slug,
+          title: (frontMatter.title as string) || 'Untitled Page', // Default title if not in front matter
+          markdownContent: markdownBody,
+        };
+        setPage(pageData);
+      })
+      .catch(err => {
+        console.error('Error processing page content:', err);
+        setError(`Could not load page content. ${err.message}`);
+      })
+      .finally(() => {
+        setIsLoading(false);
+      });
+
+  }, [slug]);
+
+  if (isLoading) {
+    return (
+      <div className="flex justify-center items-center min-h-[calc(100vh-200px)]">
+        <div className="animate-spin rounded-full h-16 w-16 border-t-4 border-b-4 border-primary-600"></div>
+        <p className="ml-4 text-lg text-gray-700">Loading page...</p>
+      </div>
+    );
+  }
+
+  if (error || !page) {
+    return (
+      <div className="container mx-auto px-4 py-8 text-center">
+        <h1 className="text-4xl font-bold text-red-600 mb-4">Error</h1>
+        <p className="text-lg text-gray-700 mb-6">{error || 'Page data could not be loaded.'}</p>
+        <Link
+          href="/"
+          className="bg-primary-600 text-white font-semibold px-6 py-3 rounded hover:bg-primary-700 transition-colors duration-300"
+        >
+          Back to Home
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container mx-auto px-4 py-8 max-w-4xl">
+      <article className="bg-white rounded-lg shadow-xl p-6 md:p-10">
+        <header className="mb-8 border-b pb-6 border-gray-200">
+          <h1 className="text-4xl md:text-5xl font-extrabold text-primary-800">{page.title}</h1>
+        </header>
+
+        {page.markdownContent ? (
+          <MarkdownRenderer content={page.markdownContent} />
+        ) : (
+          <p className="text-gray-500">Content is not available for this page.</p>
+        )}
+
+        <footer className="mt-12 pt-6 border-t border-gray-200">
+          <Link
+            href="/"
+            className="text-primary-600 hover:text-primary-800 hover:underline font-semibold transition-colors"
+          >
+            &larr; Back to Home
+          </Link>
+        </footer>
+      </article>
+    </div>
+  );
+};
+
+export default GenericPage;

--- a/app/post/[slug]/page.tsx
+++ b/app/post/[slug]/page.tsx
@@ -1,0 +1,271 @@
+"use client";
+
+import React, { useEffect, useState } from 'react';
+import { useParams } from 'next/navigation';
+import Link from 'next/link';
+import { Post } from '../../../types';
+import MarkdownRenderer from '../../../components/MarkdownRenderer';
+import { parseFrontMatter } from '../../../utils/frontMatterParser';
+
+// SVG Icons for Social Sharing (remain unchanged)
+const TwitterIcon: React.FC<{ className?: string }> = ({ className = "h-5 w-5" }) => (
+  <svg xmlns="http://www.w3.org/2000/svg" className={className} fill="currentColor" viewBox="0 0 24 24">
+    <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
+  </svg>
+);
+
+const FacebookIcon: React.FC<{ className?: string }> = ({ className = "h-5 w-5" }) => (
+  <svg xmlns="http://www.w3.org/2000/svg" className={className} fill="currentColor" viewBox="0 0 24 24">
+    <path d="M9 8h-3v4h3v12h5v-12h3.642l.358-4h-4v-1.667c0-.955.192-1.333 1.115-1.333h2.885v-5h-3.808c-3.596 0-5.192 1.583-5.192 4.615v3.385z" />
+  </svg>
+);
+
+const LinkedInIcon: React.FC<{ className?: string }> = ({ className = "h-5 w-5" }) => (
+  <svg xmlns="http://www.w3.org/2000/svg" className={className} fill="currentColor" viewBox="0 0 24 24">
+    <path d="M4.98 3.5c0 1.381-1.11 2.5-2.48 2.5s-2.48-1.119-2.48-2.5c0-1.38 1.11-2.5 2.48-2.5s2.48 1.12 2.48 2.5zm.02 4.5h-5v16h5v-16zm7.982 0h-4.968v16h4.969v-8.399c0-4.67 6.029-5.052 6.029 0v8.399h4.988v-10.131c0-7.88-8.922-7.59-11.018-3.714v-2.155z" />
+  </svg>
+);
+
+const EmailIcon: React.FC<{ className?: string }> = ({ className = "h-5 w-5" }) => (
+  <svg xmlns="http://www.w3.org/2000/svg" className={className} viewBox="0 0 20 20" fill="currentColor">
+    <path d="M2.003 5.884L10 9.882l7.997-3.998A2 2 0 0016 4H4a2 2 0 00-1.997 1.884z" />
+    <path d="M18 8.118l-8 4-8-4V14a2 2 0 002 2h12a2 2 0 002-2V8.118z" />
+  </svg>
+);
+
+const DEFAULT_POST_PAGE_VALUES: Omit<Post, 'slug'> = {
+  title: 'Untitled Post',
+  date: new Date().toISOString().split('T')[0],
+  author: 'Unknown Author',
+  excerpt: 'No excerpt available for this post.',
+  tags: [],
+  imageUrl: undefined,
+  markdownContent: '# Content Not Found\n\nSorry, the content for this post could not be loaded.',
+};
+
+
+const PostPage: React.FC = () => {
+  const params = useParams();
+  const slug = typeof params?.slug === 'string' ? params.slug : undefined;
+  const [post, setPost] = useState<Post | undefined>(undefined);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!slug) {
+      setError('Post slug is missing.');
+      setIsLoading(false);
+      setPost({ ...DEFAULT_POST_PAGE_VALUES, slug: 'unknown-slug'});
+      return;
+    }
+
+    setIsLoading(true);
+    setError(null);
+    setPost(undefined); 
+
+    fetch(`/content/posts/${slug}.md`)
+      .then(response => {
+        if (!response.ok) {
+          throw new Error(`Failed to fetch markdown: ${response.statusText} (status: ${response.status})`);
+        }
+        return response.text();
+      })
+      .then(rawContent => {
+        const { frontMatter, content: markdownBody } = parseFrontMatter(rawContent); 
+
+        // Ensure tags are always an array of strings from frontMatter
+        let tags: string[] = [];
+         if (frontMatter.tags) {
+            if (typeof frontMatter.tags === 'string') {
+                tags = frontMatter.tags.split(',').map(tag => tag.trim()).filter(tag => tag);
+            } else if (Array.isArray(frontMatter.tags)) {
+                tags = frontMatter.tags.map(tag => String(tag).trim()).filter(tag => tag);
+            }
+        }
+
+
+        const combinedPostData: Post = {
+          slug: slug,
+          title: (frontMatter.title as string) || DEFAULT_POST_PAGE_VALUES.title,
+          date: (frontMatter.date as string) || DEFAULT_POST_PAGE_VALUES.date,
+          author: (frontMatter.author as string) || DEFAULT_POST_PAGE_VALUES.author,
+          excerpt: (frontMatter.excerpt as string) || DEFAULT_POST_PAGE_VALUES.excerpt,
+          tags: tags.length > 0 ? tags : DEFAULT_POST_PAGE_VALUES.tags,
+          imageUrl: (frontMatter.imageUrl as string) || DEFAULT_POST_PAGE_VALUES.imageUrl,
+          markdownContent: markdownBody || DEFAULT_POST_PAGE_VALUES.markdownContent,
+        };
+        setPost(combinedPostData);
+      })
+      .catch(err => {
+        console.error('Error processing post content:', err);
+        setError(`Could not load post content. ${err.message}`);
+        setPost({ ...DEFAULT_POST_PAGE_VALUES, slug: slug, title: `Error: ${slug}` });
+      })
+      .finally(() => {
+        setIsLoading(false);
+      });
+
+  }, [slug]);
+
+  const handleShare = (platform: 'twitter' | 'facebook' | 'linkedin' | 'email') => {
+    if (!post) return;
+
+    const postUrl = window.location.href; 
+    const encodedPostUrl = encodeURIComponent(postUrl);
+    const postTitle = encodeURIComponent(post.title);
+    const postExcerpt = encodeURIComponent(post.excerpt);
+
+    let shareUrl = '';
+
+    switch (platform) {
+      case 'twitter':
+        shareUrl = `https://twitter.com/intent/tweet?url=${encodedPostUrl}&text=${postTitle}`;
+        break;
+      case 'facebook':
+        shareUrl = `https://www.facebook.com/sharer/sharer.php?u=${encodedPostUrl}`;
+        break;
+      case 'linkedin':
+        shareUrl = `https://www.linkedin.com/shareArticle?mini=true&url=${encodedPostUrl}&title=${postTitle}&summary=${postExcerpt}`;
+        break;
+      case 'email':
+        window.location.href = `mailto:?subject=${postTitle}&body=${encodeURIComponent('Check out this post: ' + postUrl)}`;
+        return; 
+    }
+    window.open(shareUrl, '_blank', 'noopener,noreferrer');
+  };
+
+
+  if (isLoading) { 
+    return (
+      <div className="flex justify-center items-center min-h-screen">
+        <div className="animate-spin rounded-full h-16 w-16 border-t-4 border-b-4 border-primary-600"></div>
+        <p className="ml-4 text-lg text-gray-700">Loading post...</p>
+      </div>
+    );
+  }
+  
+  // If error state is set, or post is somehow still undefined after loading
+  if (error && (!post || post.title.startsWith('Error:'))) { 
+     return (
+      <div className="container mx-auto px-4 py-8 text-center">
+        <h1 className="text-4xl font-bold text-red-600 mb-4">Error</h1>
+        <p className="text-lg text-gray-700 mb-6">{error || 'Post data could not be loaded.'}</p>
+        <Link
+          href="/"
+          className="bg-primary-600 text-white font-semibold px-6 py-3 rounded hover:bg-primary-700 transition-colors duration-300"
+        >
+          Back to Home
+        </Link>
+      </div>
+    );
+  }
+
+  // If no error, but post is somehow still undefined (should be caught by error state or default post)
+  if (!post) {
+      return (
+      <div className="container mx-auto px-4 py-8 text-center">
+        <h1 className="text-4xl font-bold text-red-600 mb-4">Post Not Found</h1>
+        <p className="text-lg text-gray-700 mb-6">The requested post could not be found.</p>
+        <Link
+          href="/"
+          className="bg-primary-600 text-white font-semibold px-6 py-3 rounded hover:bg-primary-700 transition-colors duration-300"
+        >
+          Back to Home
+        </Link>
+      </div>
+    );
+  }
+  
+  return (
+    <div className="container mx-auto px-4 py-8 max-w-4xl">
+      <article className="bg-white rounded-lg shadow-xl p-6 md:p-10">
+        <header className="mb-8 border-b pb-6 border-gray-200">
+          <h1 className="text-4xl md:text-5xl font-extrabold text-primary-800 mb-3">{post.title}</h1>
+          <div className="text-md text-gray-500">
+            <span>By {post.author}</span> | <span>Published on {new Date(post.date).toLocaleDateString()}</span>
+          </div>
+          {post.tags && post.tags.length > 0 && (
+            <div className="mt-4">
+              {post.tags.map(tag => (
+                <Link
+                  key={tag}
+                  href={`/tags/${encodeURIComponent(tag)}`}
+                  className="inline-block bg-primary-100 text-primary-700 text-xs font-semibold mr-2 mb-2 px-2.5 py-0.5 rounded-full hover:bg-primary-200 hover:text-primary-800 transition-colors duration-200"
+                  aria-label={`View posts tagged with ${tag}`}
+                >
+                  {tag}
+                </Link>
+              ))}
+            </div>
+          )}
+        </header>
+
+        {post.imageUrl && (
+          <div className="mb-8 rounded-lg overflow-hidden shadow-lg">
+            <img 
+              src={post.imageUrl} 
+              alt={`Featured image for ${post.title}`} 
+              className="w-full h-auto max-h-[500px] object-cover" 
+            />
+          </div>
+        )}
+        
+        {post.markdownContent ? (
+          <MarkdownRenderer content={post.markdownContent} />
+        ) : (
+           <p className="text-gray-500">Content is not available for this post.</p>
+        )}
+
+        {/* Social Share Section */}
+        <div className="mt-10 pt-8 border-t border-gray-200">
+          <h3 className="text-xl font-semibold text-gray-800 mb-4">Share this post</h3>
+          <div className="flex items-center space-x-3 sm:space-x-4">
+            <button
+              onClick={() => handleShare('twitter')}
+              aria-label="Share on Twitter"
+              title="Share on Twitter"
+              className="text-gray-500 hover:text-[#1DA1F2] p-2.5 rounded-full hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[#1DA1F2] transition-colors duration-200"
+            >
+              <TwitterIcon />
+            </button>
+            <button
+              onClick={() => handleShare('facebook')}
+              aria-label="Share on Facebook"
+              title="Share on Facebook"
+              className="text-gray-500 hover:text-[#1877F2] p-2.5 rounded-full hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[#1877F2] transition-colors duration-200"
+            >
+              <FacebookIcon />
+            </button>
+            <button
+              onClick={() => handleShare('linkedin')}
+              aria-label="Share on LinkedIn"
+              title="Share on LinkedIn"
+              className="text-gray-500 hover:text-[#0A66C2] p-2.5 rounded-full hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[#0A66C2] transition-colors duration-200"
+            >
+              <LinkedInIcon />
+            </button>
+            <button
+              onClick={() => handleShare('email')}
+              aria-label="Share via Email"
+              title="Share via Email"
+              className="text-gray-500 hover:text-primary-600 p-2.5 rounded-full hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500 transition-colors duration-200"
+            >
+              <EmailIcon />
+            </button>
+          </div>
+        </div>
+
+        <footer className="mt-12 pt-6 border-t border-gray-200">
+          <Link
+            href="/"
+            className="text-primary-600 hover:text-primary-800 hover:underline font-semibold transition-colors"
+          >
+            &larr; Back to all posts
+          </Link>
+        </footer>
+      </article>
+    </div>
+  );
+};
+
+export default PostPage;

--- a/app/tags/[tagName]/page.tsx
+++ b/app/tags/[tagName]/page.tsx
@@ -1,0 +1,134 @@
+
+"use client";
+
+import React, { useEffect, useState } from 'react';
+import { useParams } from 'next/navigation';
+import Link from 'next/link';
+import { fetchPostMetadataBySlug } from '../../../utils/postUtils';
+import PostCard from '../../../components/PostCard';
+import { Post } from '../../../types';
+
+// ALL_POST_SLUGS removed
+
+const PostsByTagPage: React.FC = () => {
+  const params = useParams();
+  const encodedTagName = params?.tagName;
+  const tagName = typeof encodedTagName === 'string' ? decodeURIComponent(encodedTagName) : undefined;
+
+  const [filteredPosts, setFilteredPosts] = useState<Omit<Post, 'markdownContent'>[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!tagName) {
+      setError("Tag name not specified.");
+      setIsLoading(false);
+      return;
+    }
+
+    const loadPostsByTag = async () => {
+      setIsLoading(true);
+      setError(null);
+      try {
+        const manifestResponse = await fetch('/content/post-manifest.json');
+        if (!manifestResponse.ok) {
+          throw new Error(`Failed to fetch post manifest: ${manifestResponse.statusText} (status ${manifestResponse.status})`);
+        }
+        const postSlugs: string[] = await manifestResponse.json();
+
+        if (!Array.isArray(postSlugs)) {
+            throw new Error('Post manifest is not a valid array.');
+        }
+        
+        if (postSlugs.length === 0) {
+          setFilteredPosts([]);
+          setIsLoading(false);
+          return;
+        }
+
+        const postsMetadata = await Promise.all(
+          postSlugs.map(slug => fetchPostMetadataBySlug(slug))
+        );
+        const validPosts = postsMetadata.filter(post => !post.title.startsWith('Error Loading:'));
+        
+        const postsForTag = validPosts.filter(post => 
+          post.tags.map(t => t.toLowerCase()).includes(tagName.toLowerCase())
+        );
+        
+        const sortedPosts = postsForTag.sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
+        setFilteredPosts(sortedPosts);
+
+      } catch (err: unknown) {
+        console.error(`Failed to load posts for tag "${tagName}":`, err);
+        const message = err instanceof Error ? err.message : String(err);
+        const userActionMessage = "This usually means the file '/content/post-manifest.json' is missing in your 'public/content/' folder or is not accessible. Please create this file with a JSON array of your post slugs (e.g., [\"my-first-post\", \"another-post\"]).";
+        setError(`Error loading posts for tag "${tagName}": ${message}. ${userActionMessage}`);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    loadPostsByTag();
+  }, [tagName]);
+
+  if (isLoading) {
+    return (
+      <div className="flex justify-center items-center min-h-[calc(100vh-200px)]">
+        <div className="animate-spin rounded-full h-16 w-16 border-t-4 border-b-4 border-primary-600"></div>
+        <p className="ml-4 text-lg text-gray-700">Loading posts for tag: {tagName}...</p>
+      </div>
+    );
+  }
+
+  if (error) {
+     return (
+      <div className="container mx-auto px-4 py-8 text-center">
+        <h1 className="text-3xl font-bold text-red-600 mb-4">Error Loading Posts</h1>
+        <p className="text-lg text-gray-700 whitespace-pre-line">{error}</p>
+        <Link
+          href="/tags"
+          className="mt-6 inline-block bg-primary-600 text-white font-semibold px-6 py-3 rounded hover:bg-primary-700 transition-colors duration-300"
+        >
+          View All Tags
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container mx-auto px-4 py-8">
+      <header className="mb-10">
+        <h1 className="text-4xl font-bold text-primary-800 mb-2">
+          Posts tagged with: <span className="text-primary-600">{tagName || 'Unknown Tag'}</span>
+        </h1>
+        <Link
+          href="/tags"
+          className="text-primary-600 hover:text-primary-800 hover:underline font-semibold transition-colors"
+        >
+          &larr; View all tags
+        </Link>
+      </header>
+
+      {filteredPosts.length > 0 ? (
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
+          {filteredPosts.map(post => (
+            <PostCard key={post.slug} post={post as Post} /> 
+          ))}
+        </div>
+      ) : (
+        <div className="text-center py-12">
+          <h2 className="text-2xl font-semibold text-gray-700">No posts found for this tag.</h2>
+          <p className="text-gray-500 mt-2">Try browsing other tags or viewing all posts. Ensure the post manifest is configured if you expect posts here.</p>
+          <Link
+            href="/"
+            className="mt-6 inline-block bg-primary-600 text-white font-semibold px-6 py-3 rounded hover:bg-primary-700 transition-colors duration-300"
+          >
+            View All Posts
+          </Link>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default PostsByTagPage;

--- a/app/tags/page.tsx
+++ b/app/tags/page.tsx
@@ -1,0 +1,103 @@
+
+"use client";
+
+import React, { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { fetchPostMetadataBySlug } from '../../utils/postUtils';
+
+// ALL_POST_SLUGS removed
+
+const TagsPage: React.FC = () => {
+  const [tags, setTags] = useState<string[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const loadTags = async () => {
+      setIsLoading(true);
+      setError(null);
+      try {
+        const manifestResponse = await fetch('/content/post-manifest.json');
+        if (!manifestResponse.ok) {
+          throw new Error(`Failed to fetch post manifest: ${manifestResponse.statusText} (status ${manifestResponse.status})`);
+        }
+        const postSlugs: string[] = await manifestResponse.json();
+
+        if (!Array.isArray(postSlugs)) {
+            throw new Error('Post manifest is not a valid array.');
+        }
+        
+        if (postSlugs.length === 0) {
+          setTags([]);
+          setIsLoading(false);
+          return;
+        }
+
+        const postsMetadata = await Promise.all(
+          postSlugs.map(slug => fetchPostMetadataBySlug(slug))
+        );
+        const validPosts = postsMetadata.filter(post => !post.title.startsWith('Error Loading:'));
+        const allTagsWithDuplicates = validPosts.flatMap(post => post.tags);
+        const uniqueTags = Array.from(new Set(allTagsWithDuplicates)).sort((a, b) => a.localeCompare(b));
+        setTags(uniqueTags);
+      } catch (err: unknown) {
+        console.error("Failed to load tags:", err);
+        const message = err instanceof Error ? err.message : String(err);
+        const userActionMessage = "This usually means the file '/content/post-manifest.json' is missing in your 'public/content/' folder or is not accessible. Please create this file with a JSON array of your post slugs (e.g., [\"my-first-post\", \"another-post\"]).";
+        setError(`Error: ${message}. ${userActionMessage}`);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+    loadTags();
+  }, []);
+
+  if (isLoading) {
+    return (
+      <div className="flex justify-center items-center min-h-[calc(100vh-200px)]">
+        <div className="animate-spin rounded-full h-16 w-16 border-t-4 border-b-4 border-primary-600"></div>
+        <p className="ml-4 text-lg text-gray-700">Loading tags...</p>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="container mx-auto px-4 py-8 text-center">
+        <h1 className="text-3xl font-bold text-red-600 mb-4">Error Loading Tags</h1>
+        <p className="text-lg text-gray-700 whitespace-pre-line">{error}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container mx-auto px-4 py-8">
+      <header className="mb-10 text-center">
+        <h1 className="text-5xl font-extrabold text-primary-800">All Tags</h1>
+        <p className="text-xl text-gray-600 mt-2">Browse posts by topic.</p>
+      </header>
+
+      {tags.length > 0 ? (
+        <div className="flex flex-wrap justify-center gap-4">
+          {tags.map(tag => (
+            <Link
+              key={tag}
+              href={`/tags/${encodeURIComponent(tag)}`}
+              className="bg-primary-600 text-white text-lg font-semibold px-6 py-3 rounded-lg shadow hover:bg-primary-700 transition-all duration-300 ease-in-out transform hover:scale-105 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2"
+              aria-label={`View posts tagged with ${tag}`}
+            >
+              {tag}
+            </Link>
+          ))}
+        </div>
+      ) : (
+        <div className="text-center py-12">
+          <h2 className="text-2xl font-semibold text-gray-700">No tags found.</h2>
+          <p className="text-gray-500 mt-2">It looks like there are no tags associated with any posts yet, or the post manifest file is not configured.</p>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default TagsPage;

--- a/components/AnalyticsRouteChangeTracker.tsx
+++ b/components/AnalyticsRouteChangeTracker.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import React, { useEffect } from 'react';
+import { usePathname } from 'next/navigation';
+import { useCookieConsent } from '../contexts/CookieConsentContext';
+import { useSiteConfig } from '../contexts/SiteConfigContext';
+import { sendPageView } from '../utils/analytics';
+
+const AnalyticsRouteChangeTracker: React.FC = () => {
+  const pathname = usePathname();
+  const { consentGiven } = useCookieConsent();
+  const { config: siteConfig, isLoading: isSiteConfigLoading } = useSiteConfig();
+
+  useEffect(() => {
+    // Send page view if consent is given, GA is configured, and site config is loaded
+    if (consentGiven && !isSiteConfigLoading && siteConfig.gaMeasurementId && window.gtag) {
+      // location.pathname for HashRouter gives the path after #, e.g., "/post/my-slug"
+      sendPageView(location.pathname, siteConfig.gaMeasurementId);
+    }
+  }, [pathname, consentGiven, siteConfig.gaMeasurementId, isSiteConfigLoading]);
+
+  return null; // This component does not render anything
+};
+
+export default AnalyticsRouteChangeTracker;

--- a/components/CookieConsentBanner.tsx
+++ b/components/CookieConsentBanner.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import React from 'react';
+import Link from 'next/link';
+import { useCookieConsent } from '../contexts/CookieConsentContext';
+
+const CookieConsentBanner: React.FC = () => {
+  const { showBanner, giveConsent, declineConsent } = useCookieConsent();
+
+  if (!showBanner) {
+    return null;
+  }
+
+  return (
+    <div 
+      className="fixed bottom-0 left-0 right-0 bg-primary-800 text-white p-4 shadow-lg z-[100]"
+      role="dialog"
+      aria-live="polite"
+      aria-label="Consenso cookie"
+    >
+      <div className="container mx-auto flex flex-col sm:flex-row justify-between items-center">
+        <p className="text-sm mb-3 sm:mb-0 sm:mr-4">
+          Utilizziamo i cookie per migliorare la tua esperienza e per finalità analitiche, previo tuo consenso. 
+          Per maggiori dettagli, consulta la nostra{' '}
+          <Link to="/page/privacy-policy" className="underline hover:text-primary-200">
+            Informativa Privacy e Cookie Policy
+          </Link>.
+        </p>
+        <div className="flex space-x-3">
+          <button
+            onClick={declineConsent}
+            className="px-4 py-2 text-sm font-medium rounded-md bg-primary-600 hover:bg-primary-500 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-primary-800 focus:ring-white"
+            aria-label="Rifiuta cookie"
+          >
+            Rifiuta
+          </button>
+          <button
+            onClick={giveConsent}
+            className="px-4 py-2 text-sm font-medium rounded-md bg-green-500 hover:bg-green-600 text-white focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-primary-800 focus:ring-green-300"
+            aria-label="Accetta cookie"
+          >
+            Accetta
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default CookieConsentBanner;

--- a/components/MarkdownRenderer.tsx
+++ b/components/MarkdownRenderer.tsx
@@ -1,0 +1,65 @@
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import React from 'react';
+import ReactMarkdown, { Components } from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+
+interface MarkdownRendererProps {
+  content: string;
+}
+
+// Define the expected props structure for the 'code' component
+// based on react-markdown's typical signature.
+type CodeComponentProps = {
+  inline?: boolean;
+  className?: string;
+  children: React.ReactNode;
+  // Allows for other HTML attributes to be collected by ...props
+  [key: string]: any; 
+};
+
+const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({ content }) => {
+  const customComponents: Components = {
+    h1: ({ ...props }) => <h1 className="text-4xl font-bold my-6 border-b pb-2 border-gray-300" {...props} />,
+    h2: ({ ...props }) => <h2 className="text-3xl font-semibold my-5 border-b pb-2 border-gray-200" {...props} />,
+    h3: ({ ...props }) => <h3 className="text-2xl font-semibold my-4" {...props} />,
+    p: ({ ...props }) => <p className="my-4 leading-relaxed" {...props} />,
+    a: ({ ...props }) => <a className="text-primary-600 hover:text-primary-800 underline" {...props} />,
+    ul: ({ ...props }) => <ul className="list-disc pl-8 my-4 space-y-1" {...props} />,
+    ol: ({ ...props }) => <ol className="list-decimal pl-8 my-4 space-y-1" {...props} />,
+    li: ({ ...props }) => <li className="my-1" {...props} />,
+    code: ({ inline, className, children, ...props }: CodeComponentProps) => {
+      const match = /language-(\w+)/.exec(className || '');
+      if (!inline && match) {
+        return (
+          <pre className="bg-gray-900 text-white p-4 rounded-md my-4 overflow-x-auto">
+            <code className={`language-${match[1]}`} {...props}>
+              {String(children).replace(/\n$/, '')}
+            </code>
+          </pre>
+        );
+      }
+      // For inline code, ensure className is handled gracefully
+      return (
+        <code className={`bg-gray-200 text-red-600 px-1 py-0.5 rounded text-sm ${className || ''}`} {...props}>
+          {children}
+        </code>
+      );
+    },
+    blockquote: ({ ...props }) => <blockquote className="border-l-4 border-gray-300 pl-4 italic my-4 text-gray-600" {...props} />,
+  };
+
+  return (
+    <div className="prose prose-lg max-w-none text-gray-800">
+      <ReactMarkdown
+        remarkPlugins={[remarkGfm]}
+        components={customComponents}
+      >
+        {content}
+      </ReactMarkdown>
+    </div>
+  );
+};
+
+export default MarkdownRenderer;

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import React, { useState, useEffect } from 'react';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { useSiteConfig } from '../contexts/SiteConfigContext';
+
+const Navbar: React.FC = () => {
+  const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
+  const pathname = usePathname();
+  const { config, isLoading: isConfigLoading, error: configError } = useSiteConfig();
+
+  // Close mobile menu on route change
+  useEffect(() => {
+    setIsMobileMenuOpen(false);
+  }, [pathname]);
+
+  const toggleMobileMenu = () => {
+    setIsMobileMenuOpen(!isMobileMenuOpen);
+  };
+
+  const getNavLinkClass = (path: string) =>
+    pathname === path
+      ? "text-primary-200 border-b-2 border-primary-200 pb-1"
+      : "hover:text-primary-200 transition-colors pb-1 border-b-2 border-transparent hover:border-primary-300";
+
+  const getMobileNavLinkClass = (path: string) =>
+    pathname === path
+      ? "block py-2 px-3 text-primary-200 bg-primary-600 rounded"
+      : "block py-2 px-3 hover:bg-primary-600 hover:text-primary-100 rounded transition-colors";
+
+  const navLinks = [
+    { to: "/", text: "Home" },
+    { to: "/tags", text: "Tags" },
+    { to: "/page/about", text: "About" },
+    { to: "/page/privacy-policy", text: "Informativa Privacy" },
+  ];
+
+  const displayTitle = isConfigLoading ? "Loading..." : (configError ? "Blog" : config.blogTitle);
+
+  return (
+    <nav className="bg-primary-700 text-white shadow-md sticky top-0 z-50">
+      <div className="container mx-auto px-6 py-4 flex justify-between items-center">
+        <Link href="/" className="text-2xl font-bold hover:text-primary-200 transition-colors" aria-label="Go to homepage">
+          {displayTitle}
+        </Link>
+
+        {/* Desktop Menu */}
+        <div className="hidden md:flex space-x-6 items-center">
+          {navLinks.map(link => (
+            <Link key={link.to} href={link.to} className={getNavLinkClass(link.to)}>
+              {link.text}
+            </Link>
+          ))}
+        </div>
+
+        {/* Mobile Menu Button */}
+        <div className="md:hidden">
+          <button
+            onClick={toggleMobileMenu}
+            aria-label="Toggle navigation menu"
+            aria-expanded={isMobileMenuOpen}
+            aria-controls="mobile-menu"
+            className="p-2 rounded-md text-primary-200 hover:text-white hover:bg-primary-600 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-white"
+          >
+            {isMobileMenuOpen ? (
+              // X icon
+              <svg className="h-6 w-6" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            ) : (
+              // Hamburger icon
+              <svg className="h-6 w-6" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16m-7 6h7" />
+              </svg>
+            )}
+          </button>
+        </div>
+      </div>
+
+      {/* Mobile Menu */}
+      {isMobileMenuOpen && (
+        <div id="mobile-menu" className="md:hidden bg-primary-700 border-t border-primary-600">
+          <div className="px-2 pt-2 pb-3 space-y-1 sm:px-3">
+            {navLinks.map(link => (
+              <Link
+                key={link.to}
+                href={link.to}
+                className={getMobileNavLinkClass(link.to)}
+                onClick={() => setIsMobileMenuOpen(false)}
+              >
+                {link.text}
+              </Link>
+            ))}
+          </div>
+        </div>
+      )}
+    </nav>
+  );
+};
+
+export default Navbar;

--- a/components/PostCard.tsx
+++ b/components/PostCard.tsx
@@ -1,0 +1,60 @@
+
+"use client";
+
+import Link from 'next/link';
+import React from 'react';
+import { Post } from '../types';
+
+interface PostCardProps {
+  post: Post;
+}
+
+const PostCard: React.FC<PostCardProps> = ({ post }) => {
+  return (
+    <article className="bg-white rounded-lg shadow-lg overflow-hidden transition-shadow hover:shadow-xl duration-300 flex flex-col">
+      {post.imageUrl && (
+        <Link href={`/post/${post.slug}`} aria-hidden="true" tabIndex={-1}>
+          <img 
+            src={post.imageUrl} 
+            alt={`Featured image for ${post.title}`} 
+            className="w-full h-48 object-cover" 
+            loading="lazy"
+          />
+        </Link>
+      )}
+      <div className="p-6 flex flex-col flex-grow">
+        <h2 className="text-2xl font-bold text-primary-700 mb-2">
+          <Link href={`/post/${post.slug}`} className="hover:underline">
+            {post.title}
+          </Link>
+        </h2>
+        <div className="text-sm text-gray-500 mb-3">
+          <span>By {post.author}</span> | <span>{new Date(post.date).toLocaleDateString()}</span>
+        </div>
+        <p className="text-gray-700 mb-4 leading-relaxed flex-grow">{post.excerpt}</p>
+        <div className="mb-4">
+          {post.tags.map(tag => (
+            <Link
+              key={tag}
+              href={`/tags/${encodeURIComponent(tag)}`}
+              className="inline-block bg-primary-100 text-primary-700 text-xs font-semibold mr-2 mb-2 px-2.5 py-0.5 rounded-full hover:bg-primary-200 hover:text-primary-800 transition-colors duration-200"
+              aria-label={`View posts tagged with ${tag}`}
+            >
+              {tag}
+            </Link>
+          ))}
+        </div>
+        <div className="mt-auto">
+          <Link
+            href={`/post/${post.slug}`}
+            className="inline-block bg-primary-600 text-white font-semibold px-4 py-2 rounded hover:bg-primary-700 transition-colors duration-300"
+          >
+            Read More &rarr;
+          </Link>
+        </div>
+      </div>
+    </article>
+  );
+};
+
+export default PostCard;

--- a/contexts/CookieConsentContext.tsx
+++ b/contexts/CookieConsentContext.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import React, { createContext, useContext, useState, useEffect, ReactNode, useCallback } from 'react';
+import { initGA } from '../utils/analytics';
+import { useSiteConfig } from './SiteConfigContext';
+
+interface CookieConsentContextType {
+  consentGiven: boolean | null; // null: undecided, true: given, false: declined
+  showBanner: boolean;
+  giveConsent: () => void;
+  declineConsent: () => void;
+}
+
+const CookieConsentContext = createContext<CookieConsentContextType | undefined>(undefined);
+
+// Helper function to safely call gtag for consent updates
+const safeGtagConsentUpdate = (consentArgs: Record<string, 'granted' | 'denied'>) => {
+  if (window.gtag) {
+    window.gtag('consent', 'update', consentArgs);
+    console.log('gtag consent updated:', consentArgs);
+  } else {
+    // This case is less likely if gtag.js is loaded, but good to be aware.
+    // The default consent state set in index.html will hold until gtag is available.
+    console.warn('gtag not available for consent update. Default consent settings apply.');
+  }
+};
+
+export const CookieConsentProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
+  const [consentGiven, setConsentGiven] = useState<boolean | null>(null);
+  const [showBanner, setShowBanner] = useState<boolean>(false);
+  const { config: siteConfig, isLoading: isSiteConfigLoading } = useSiteConfig();
+
+  const initializeConsent = useCallback(() => {
+    const storedConsent = localStorage.getItem('cookieConsent');
+    const gaId = siteConfig.gaMeasurementId;
+
+    if (storedConsent === 'true') {
+      safeGtagConsentUpdate({ 'analytics_storage': 'granted' });
+      setConsentGiven(true);
+      setShowBanner(false);
+      if (gaId && !isSiteConfigLoading && window.gtag) {
+        initGA(gaId); // initGA calls gtag('config', ...) which depends on consent
+      }
+    } else if (storedConsent === 'false') {
+      safeGtagConsentUpdate({ 'analytics_storage': 'denied' });
+      setConsentGiven(false);
+      setShowBanner(false);
+    } else {
+      // Undecided: Default consent 'denied' for analytics_storage (set in index.html) applies.
+      setConsentGiven(null);
+      setShowBanner(true);
+    }
+  }, [siteConfig.gaMeasurementId, isSiteConfigLoading]);
+
+  useEffect(() => {
+    // Initialize only when site config is loaded to ensure gaId is available
+    if (!isSiteConfigLoading) {
+        initializeConsent();
+    }
+  }, [isSiteConfigLoading, initializeConsent]);
+
+  const giveConsent = () => {
+    const gaId = siteConfig.gaMeasurementId;
+    safeGtagConsentUpdate({ 'analytics_storage': 'granted' });
+    setConsentGiven(true);
+    setShowBanner(false);
+    localStorage.setItem('cookieConsent', 'true');
+    if (gaId && !isSiteConfigLoading && window.gtag) {
+      initGA(gaId);
+    }
+  };
+
+  const declineConsent = () => {
+    safeGtagConsentUpdate({ 'analytics_storage': 'denied' });
+    setConsentGiven(false);
+    setShowBanner(false);
+    localStorage.setItem('cookieConsent', 'false');
+  };
+
+  return (
+    <CookieConsentContext.Provider value={{ consentGiven, showBanner, giveConsent, declineConsent }}>
+      {children}
+    </CookieConsentContext.Provider>
+  );
+};
+
+export const useCookieConsent = () => {
+  const context = useContext(CookieConsentContext);
+  if (context === undefined) {
+    throw new Error('useCookieConsent must be used within a CookieConsentProvider');
+  }
+  return context;
+};

--- a/contexts/SiteConfigContext.tsx
+++ b/contexts/SiteConfigContext.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import React, { createContext, useContext, useState, useEffect, ReactNode } from 'react';
+import yaml from 'js-yaml';
+
+interface SiteConfig {
+  blogTitle: string;
+  homepageHeroImageUrl?: string;
+  gaMeasurementId?: string; 
+}
+
+interface SiteConfigContextType {
+  config: SiteConfig;
+  isLoading: boolean;
+  error: string | null;
+}
+
+const defaultConfig: SiteConfig = {
+  blogTitle: "My Awesome Blog", 
+  homepageHeroImageUrl: undefined,
+  gaMeasurementId: undefined,
+};
+
+const SiteConfigContext = createContext<SiteConfigContextType>({
+  config: defaultConfig,
+  isLoading: true,
+  error: null,
+});
+
+export const SiteConfigProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
+  const [config, setConfig] = useState<SiteConfig>(defaultConfig);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchConfig = async () => {
+      try {
+        const response = await fetch('/config.yml');
+        if (!response.ok) {
+          throw new Error(`Failed to fetch config.yml: ${response.statusText} (status: ${response.status})`);
+        }
+        const yamlText = await response.text();
+        const parsedYaml = yaml.load(yamlText);
+        
+        const loadedConfigData = (typeof parsedYaml === 'object' && parsedYaml !== null ? parsedYaml : {}) as Partial<SiteConfig>;
+        
+        setConfig({
+            blogTitle: loadedConfigData.blogTitle || defaultConfig.blogTitle,
+            homepageHeroImageUrl: loadedConfigData.homepageHeroImageUrl || defaultConfig.homepageHeroImageUrl,
+            gaMeasurementId: loadedConfigData.gaMeasurementId || defaultConfig.gaMeasurementId,
+        });
+        setError(null);
+      } catch (err: any) {
+        console.error("Error loading or parsing config.yml:", err);
+        setError(err.message || "Could not load site configuration.");
+        setConfig(defaultConfig); 
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchConfig();
+  }, []);
+
+  return (
+    <SiteConfigContext.Provider value={{ config, isLoading, error }}>
+      {children}
+    </SiteConfigContext.Provider>
+  );
+};
+
+export const useSiteConfig = () => {
+  const context = useContext(SiteConfigContext);
+  if (context === undefined) {
+    throw new Error('useSiteConfig must be used within a SiteConfigProvider');
+  }
+  return context;
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,12 @@
       "name": "react-ssg-blog",
       "version": "0.1.0",
       "dependencies": {
+        "js-yaml": "^4.1.0",
         "next": "15.3.3",
         "react": "^19.0.0",
-        "react-dom": "^19.0.0"
+        "react-dom": "^19.0.0",
+        "react-markdown": "^10.1.0",
+        "remark-gfm": "^4.0.1"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -1274,12 +1277,38 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/debug": {
+      "version": "4.1.12",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
+      "integrity": "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/estree-jsx": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.5.tgz",
+      "integrity": "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*"
+      }
+    },
+    "node_modules/@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
@@ -1293,6 +1322,21 @@
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
       "license": "MIT"
     },
     "node_modules/@types/node": {
@@ -1309,7 +1353,6 @@
       "version": "19.1.7",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.7.tgz",
       "integrity": "sha512-BnsPLV43ddr05N71gaGzyZ5hzkCmGwhMvYc8zmvI8Ci1bRkkDSzDDVfAXfN2tk748OwI7ediiPX6PfT9p0QGVg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -1324,6 +1367,12 @@
       "peerDependencies": {
         "@types/react": "^19.0.0"
       }
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.34.0",
@@ -1611,6 +1660,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       }
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
+      "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
+      "license": "ISC"
     },
     "node_modules/@unrs/resolver-binding-darwin-arm64": {
       "version": "1.7.13",
@@ -1913,7 +1968,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/aria-query": {
@@ -2139,6 +2193,16 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -2261,6 +2325,16 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -2276,6 +2350,46 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-reference-invalid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
+      "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/chownr": {
@@ -2339,6 +2453,16 @@
         "simple-swizzle": "^0.2.2"
       }
     },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -2365,7 +2489,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
@@ -2433,7 +2556,6 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
       "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -2445,6 +2567,19 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.1.0.tgz",
+      "integrity": "sha512-Wy+JTSbFThEOXQIR2L6mxJvEs+veIzpmqD7ynWxMXGpnk3smkHQOp6forLdHsKpAMW9iJpaBBIxz285t1n1C3w==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/deep-is": {
@@ -2490,6 +2625,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.4.tgz",
@@ -2498,6 +2642,19 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/doctrine": {
@@ -3155,6 +3312,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-util-is-identifier-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz",
+      "integrity": "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -3164,6 +3331,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -3581,6 +3754,56 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hast-util-to-jsx-runtime": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
+      "integrity": "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "mdast-util-mdx-expression": "^2.0.0",
+        "mdast-util-mdx-jsx": "^3.0.0",
+        "mdast-util-mdxjs-esm": "^2.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "style-to-js": "^1.0.0",
+        "unist-util-position": "^5.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/html-url-attributes": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
+      "integrity": "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -3618,6 +3841,12 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/inline-style-parser": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.4.tgz",
+      "integrity": "sha512-0aO8FkhNZlj/ZIbNi7Lxxr12obT7cL1moPfE4tg1LkX7LlLfC6DeX4l2ZEud1ukP9jNQyNnfzQVqwbwmAATY4Q==",
+      "license": "MIT"
+    },
     "node_modules/internal-slot": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
@@ -3631,6 +3860,30 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-alphabetical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+      "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-alphanumerical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+      "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-alphabetical": "^2.0.0",
+        "is-decimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/is-array-buffer": {
@@ -3785,6 +4038,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-decimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+      "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -3843,6 +4106,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-hexadecimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
+      "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/is-map": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
@@ -3894,6 +4167,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-regex": {
@@ -4094,7 +4379,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -4459,6 +4743,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/longest-streak": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -4482,6 +4776,16 @@
         "@jridgewell/sourcemap-codec": "^1.5.0"
       }
     },
+    "node_modules/markdown-table": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+      "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -4490,6 +4794,288 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+      "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mdast-util-from-markdown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.2.tgz",
+      "integrity": "sha512-uZhTV/8NBuw0WHkPTrCqDOl0zVe1BIng5ZtHoDk49ME1qqcjYmmLmOf0gELgcRMxN4w2iuIeVso5/6QymSrgmA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark": "^4.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+      "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-gfm-autolink-literal": "^2.0.0",
+        "mdast-util-gfm-footnote": "^2.0.0",
+        "mdast-util-gfm-strikethrough": "^2.0.0",
+        "mdast-util-gfm-table": "^2.0.0",
+        "mdast-util-gfm-task-list-item": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-autolink-literal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+      "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-find-and-replace": "^3.0.0",
+        "micromark-util-character": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-strikethrough": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+      "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-table": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+      "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "markdown-table": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-task-list-item": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+      "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-expression": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz",
+      "integrity": "sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-jsx": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-3.2.0.tgz",
+      "integrity": "sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "parse-entities": "^4.0.0",
+        "stringify-entities": "^4.0.0",
+        "unist-util-stringify-position": "^4.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdxjs-esm": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdxjs-esm/-/mdast-util-mdxjs-esm-2.0.1.tgz",
+      "integrity": "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-phrasing": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+      "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.0.tgz",
+      "integrity": "sha512-QGYKEuUsYT9ykKBCMOEDLsU5JRObWQusAolFMeko/tYPufNkRffBAQjIE+99jbA87xv6FgmjLtwjh9wBWajwAA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-markdown": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+      "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/merge2": {
@@ -4501,6 +5087,569 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/micromark": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-core-commonmark": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+      "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-destination": "^2.0.0",
+        "micromark-factory-label": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-title": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-html-tag-name": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-gfm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+      "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-extension-gfm-autolink-literal": "^2.0.0",
+        "micromark-extension-gfm-footnote": "^2.0.0",
+        "micromark-extension-gfm-strikethrough": "^2.0.0",
+        "micromark-extension-gfm-table": "^2.0.0",
+        "micromark-extension-gfm-tagfilter": "^2.0.0",
+        "micromark-extension-gfm-task-list-item": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-autolink-literal": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+      "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-strikethrough": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+      "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-table": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+      "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-tagfilter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+      "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-task-list-item": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+      "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-factory-destination": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+      "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-label": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+      "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-space": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-title": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+      "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-whitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+      "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-chunked": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-classify-character": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+      "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-combine-extensions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+      "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+      "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+      "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-html-tag-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+      "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-normalize-identifier": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+      "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-resolve-all": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-subtokenize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+      "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
@@ -4582,7 +5731,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -4912,6 +6060,31 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse-entities": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
+      "integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "character-entities-legacy": "^3.0.0",
+        "character-reference-invalid": "^2.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "is-alphanumerical": "^2.0.0",
+        "is-decimal": "^2.0.0",
+        "is-hexadecimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/parse-entities/node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "license": "MIT"
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -5019,6 +6192,16 @@
         "react-is": "^16.13.1"
       }
     },
+    "node_modules/property-information": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
+      "integrity": "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -5078,6 +6261,33 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/react-markdown": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-10.1.0.tgz",
+      "integrity": "sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "hast-util-to-jsx-runtime": "^2.0.0",
+        "html-url-attributes": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.0.0",
+        "unified": "^11.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18",
+        "react": ">=18"
+      }
+    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
@@ -5120,6 +6330,72 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/remark-gfm": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
+      "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-gfm": "^3.0.0",
+        "micromark-extension-gfm": "^3.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-parse": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+      "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-rehype": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
+      "integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-stringify": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+      "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/resolve": {
@@ -5481,6 +6757,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/stable-hash": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.5.tgz",
@@ -5623,6 +6909,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/strip-bom": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
@@ -5644,6 +6944,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/style-to-js": {
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.16.tgz",
+      "integrity": "sha512-/Q6ld50hKYPH3d/r6nr117TZkHR0w0kGGIVfpG9N6D8NymRPM9RqCUv4pRpJ62E5DqOYx2AFpbZMyCPnjQCnOw==",
+      "license": "MIT",
+      "dependencies": {
+        "style-to-object": "1.0.8"
+      }
+    },
+    "node_modules/style-to-object": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.8.tgz",
+      "integrity": "sha512-xT47I/Eo0rwJmaXC4oilDGDWLohVhR6o/xAQcPQN8q6QBuZVL8qMYL85kLmST5cPjAorwvqIA4qXTRQoYHaL6g==",
+      "license": "MIT",
+      "dependencies": {
+        "inline-style-parser": "0.2.4"
       }
     },
     "node_modules/styled-jsx": {
@@ -5786,6 +7104,26 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/trough": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/ts-api-utils": {
@@ -5951,6 +7289,93 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/unified": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "bail": "^2.0.0",
+        "devlop": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.0.tgz",
+      "integrity": "sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.0.0.tgz",
+      "integrity": "sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.1.tgz",
+      "integrity": "sha512-L/PqWzfTP9lzzEa6CKs0k2nARxTdZduw3zyh8d2NVBnsyvHjSX4TWse388YrrQKbvI8w20fGjGlhgT96WwKykw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/unrs-resolver": {
       "version": "1.7.13",
       "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.7.13.tgz",
@@ -5992,6 +7417,34 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.2.tgz",
+      "integrity": "sha512-jRDZ1IMLttGj41KcZvlrYAaI3CfqpLpfpf+Mfig13viT6NKvRzWZ+lXz0Y5D60w6uJIBAOGq9mSHf0gktF0duw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/which": {
@@ -6130,6 +7583,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -9,19 +9,22 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "js-yaml": "^4.1.0",
+    "next": "15.3.3",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "next": "15.3.3"
+    "react-markdown": "^10.1.0",
+    "remark-gfm": "^4.0.1"
   },
   "devDependencies": {
-    "typescript": "^5",
+    "@eslint/eslintrc": "^3",
+    "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
-    "@tailwindcss/postcss": "^4",
-    "tailwindcss": "^4",
     "eslint": "^9",
     "eslint-config-next": "15.3.3",
-    "@eslint/eslintrc": "^3"
+    "tailwindcss": "^4",
+    "typescript": "^5"
   }
 }

--- a/public/config.yml
+++ b/public/config.yml
@@ -1,0 +1,3 @@
+blogTitle: "My React Markdown Blog"
+homepageHeroImageUrl: "https://picsum.photos/seed/homepage-hero/1200/400" # A placeholder hero image for the homepage
+gaMeasurementId: "G-XXXXXXXXXX" # Replace with your actual Google Analytics Measurement ID

--- a/public/content/pages/about.md
+++ b/public/content/pages/about.md
@@ -1,0 +1,21 @@
+---
+title: About Our Journey
+---
+
+## Welcome to My Tech Journey!
+
+This blog is a space where I document my explorations, learnings, and reflections in the vast world of technology. From delving into new JavaScript frameworks and mastering CSS techniques to understanding the intricacies of backend systems and cloud computing, I aim to share insights that are both practical and thought-provoking.
+
+### Our Mission
+
+Our mission is to:
+
+-   **Share Knowledge**: Provide clear, concise, and helpful tutorials and articles.
+-   **Foster Community**: Create a space for developers to learn and grow together.
+-   **Inspire Curiosity**: Encourage continuous learning and exploration in tech.
+
+### Who Am I?
+
+I'm a passionate developer (just like you, perhaps!) with a keen interest in building useful and elegant solutions. This blog serves as a personal notebook and a way to give back to the developer community that has taught me so much.
+
+Thank you for stopping by! I hope you find something valuable here.

--- a/public/content/pages/privacy-policy.md
+++ b/public/content/pages/privacy-policy.md
@@ -1,0 +1,60 @@
+---
+title: Informativa sulla Privacy e Cookie Policy
+---
+
+## Informativa sul Trattamento dei Dati Personali e Cookie Policy
+
+Recente il Garante Italiano si è pronunciato contro l'uso degli Analytics, contestandone il trasferimento dei dati degli utenti negli Stati Uniti.
+Per poter continuare ad utilizzare Google Analytics sul proprio sito è necessario:
+
+*   avere installato Google Analytics 4
+*   chiedere il consenso all'utente (Google Analytics non è più assimilabile ad un cookie tecnico)
+*   utilizzare un sistema di "proxificazione dei dati" per inviare dati anonimi ai server di Google
+
+Abbiamo realizzato quindi My Agile Pixel: la soluzione definitiva al blocco di Analytics.
+Clicca qui e vai sul sito per scoprire come configurare Google Analytics con My Agile Pixel e continuare ad utilizzarlo sul tuo sito.
+
+**Si mantiene il testo sottostante come riferimento.**
+
+---
+
+Togliamoci subito il dente:
+i cookie analitici sono di **PROFILAZIONE**, e questo è indiscutibile.
+
+### Premessa
+Nella FAQ del Garante Privacy numero 4 alla domanda «I cookie analytics sono cookie “tecnici”?», la risposta è perentoria: "**NO**"
+
+Nel secondo comma della stessa FAQ viene riportato quanto segue:
+
+“Qualora, invece, l’elaborazione di tali analisi statistiche sia affidata a soggetti terzi, i dati degli utenti dovranno essere preventivamente minimizzati e non potranno essere combinati con altre elaborazioni né trasmessi ad ulteriori terzi. A queste condizioni, per i cookie analytics valgono le stesse regole, in tema di informativa e consenso, previste per i cookie tecnici.”
+
+Che, in modo molto più semplice, significa che se impostiamo gli analytics utilizzando il principio di “privacy by default”, cioè di minimizzazione dei dati, possiamo prevedere informative e consenso con le stesse regole che usiamo per quelli tecnici, pur non essendo comunque tali.
+
+Nella FAQ numero 5, invece, alla domanda
+«È necessario il consenso dell’utente per l’installazione dei cookie sul suo terminale?», la risposta è:
+"Dipende dalle finalità per le quali i cookie vengono usati e, quindi, se sono cookie "tecnici" o di "profilazione".
+
+Ovvero, per l’installazione dei cookie tecnici e di quelli analytics impostati secondo la minimizzazione, non è richiesto il consenso degli utenti, mentre è comunque sempre necessario dare l'informativa (art. 13 del Regolamento Ue 2016/679).
+
+I cookie di profilazione veri e propri, o gli altri strumenti di tracciamento, invece, possono essere utilizzati soltanto se l’utente abbia espresso il proprio consenso dopo essere stato informato con modalità semplificate.”
+
+Nella FAQ numero 6, alla domanda
+«In che modo il titolare del sito deve fornire l’informativa semplificata e richiedere il consenso dei cookie di profilazione?», la risposta è:
+[…] "Pur nel rispetto dell’accountability del titolare e dunque della sua libertà di scelta delle misure e delle soluzioni che meglio garantiscano la conformità agli obblighi di legge, il Garante tuttavia suggerisce l’adozione di un meccanismo per il quale, nel momento in cui l’utente accede a un sito web (sulla home page o su qualunque altra pagina), compaia immediatamente un banner contenente una prima informativa "breve", la richiesta di consenso all’uso dei cookie e un link per accedere ad un’informativa più "estesa". In questa pagina, l’utente potrà reperire maggiori e più dettagliate informazioni sui cookie scegliere quali specifici cookie autorizzare."
+
+Quindi, fatte queste doverose premesse, non c’è dubbio nell’affermare che i cookie analytics sono cookie di profilazione e non tecnici, che se installati utilizzando il principio di minimizzazione dei dati possono essere utilizzati anche senza consenso, ma che, essendo dei cookie di profilazione, richiedono sempre una informativa semplificata che solitamente viene data tramite un banner privacy.
+
+Più specificatamente, se non installiamo cookie sul sito (ad eccezione di quelli tecnici per il funzionamento del sito), possiamo non utilizzare un sistema “banner”, ma occorre comunque specificarlo nell’informativa privacy del sito stesso, conosciuta ai più come Privacy Policy.
+
+Se, invece, utilizziamo degli analytics, cookie definiti dal Garante come di Profilazione, dobbiamo utilizzare un banner per una informativa breve. Possiamo però far partire gli analytics senza consenso, se utilizzati in regime di minimizzazione dei dati.
+
+### In Sintesi
+Come anticipato all’inizio, i cookie analytics sono quindi cookie di profilazione, come definito dall' Autorità Garante per la protezione dei dati personali.
+
+Da notare che inizialmente il Garante aveva dichiarato che tutti gli analytics erano di profilazione, anche in forma anonima, rettificando in seguito (correttamente, a nostro avviso), l’interpretazione della minimizzazione dei dati, permettendo, in caso di minimizzazione - e quindi anonimizzazione dei dati - di attivarli senza il pregresso consenso dell’utente.
+
+Fuorviante, invece, è intendere gli analytics come cookie tecnici, in quanto molti gestori di siti, con questa visione, potrebbero configurarli in maniera errata e farli diventare traccianti di dati personali.
+
+Infine, il Garante Privacy parla di analytics in generale, quindi non solo di Google Analytics e del mondo Google, in quanto ne esistono tanti altri per i quali valgono le stesse regole.
+
+Il nostro consiglio finale è di trattare con molta attenzione i cookie analytics, essendo un terreno piuttosto insidioso, per i quali sarebbe opportuno almeno un consulto con un esperto in merito, onde evitare salate sanzioni da parte dell’Autorità garante.

--- a/public/content/post-manifest.json
+++ b/public/content/post-manifest.json
@@ -1,0 +1,13 @@
+[
+  "getting-started-with-react-hooks",
+  "mastering-tailwind-css",
+  "understanding-async-javascript",
+  "deep-dive-into-css-grid",
+  "modern-javascript-es2023-features",
+  "building-accessible-web-applications",
+  "introduction-to-deno-runtime",
+  "graphql-vs-rest-apis",
+  "optimizing-web-performance-core-web-vitals",
+  "state-management-in-react-beyond-usestate",
+  "serverless-architecture-introduction"
+]

--- a/public/content/posts/building-accessible-web-applications.md
+++ b/public/content/posts/building-accessible-web-applications.md
@@ -1,0 +1,47 @@
+---
+title: "Building Accessible Web Applications: A Practical Guide"
+date: "2024-03-18"
+author: "Maria Garcia"
+excerpt: "Learn practical tips and techniques for making your web applications inclusive and usable by everyone, including people with disabilities."
+tags: ["Accessibility", "a11y", "Web Development", "UX", "Inclusive Design"]
+# No imageUrl for this post page.
+---
+
+# Building Accessible Web Applications: A Practical Guide
+
+Web accessibility (often abbreviated as a11y) means designing and developing websites, tools, and technologies so that people with disabilities can use them. More specifically, people can perceive, understand, navigate, and interact with the Web, and they can contribute to the Web.
+
+## Key Principles (WCAG)
+
+The Web Content Accessibility Guidelines (WCAG) are organized around four main principles, often remembered by the acronym POUR:
+
+1.  **Perceivable**: Information and user interface components must be presentable to users in ways they can perceive.
+    *   Provide text alternatives for non-text content (e.g., `alt` text for images).
+    *   Provide captions and other alternatives for multimedia.
+    *   Create content that can be presented in different ways (e.g., simpler layout) without losing information or structure.
+    *   Make it easier for users to see and hear content including separating foreground from background.
+
+2.  **Operable**: User interface components and navigation must be operable.
+    *   Make all functionality available from a keyboard.
+    *   Give users enough time to read and use content.
+    *   Do not design content in a way that is known to cause seizures.
+    *   Provide ways to help users navigate, find content, and determine where they are.
+
+3.  **Understandable**: Information and the operation of user interface must be understandable.
+    *   Make text content readable and understandable.
+    *   Make web pages appear and operate in predictable ways.
+    *   Help users avoid and correct mistakes.
+
+4.  **Robust**: Content must be robust enough that it can be interpreted reliably by a wide variety of user agents, including assistive technologies.
+    *   Maximize compatibility with current and future user agents, including assistive technologies.
+
+## Practical Tips
+
+-   **Use Semantic HTML**: Use HTML elements for their intended purpose (`<nav>`, `<button>`, `<article>`, etc.).
+-   **ARIA Attributes**: Use Accessible Rich Internet Applications (ARIA) attributes to enhance semantics where native HTML is insufficient.
+-   **Keyboard Navigation**: Ensure all interactive elements are focusable and operable via keyboard.
+-   **Color Contrast**: Check that text and background colors have sufficient contrast.
+-   **Forms**: Label all form controls clearly. Provide helpful error messages.
+-   **Testing**: Test with assistive technologies (e.g., screen readers) and automated accessibility checkers.
+
+Building accessible applications is not just a compliance issue; it's about creating a better experience for all users.

--- a/public/content/posts/deep-dive-into-css-grid.md
+++ b/public/content/posts/deep-dive-into-css-grid.md
@@ -1,0 +1,44 @@
+---
+title: "A Deep Dive into CSS Grid Layout"
+date: "2024-05-10"
+author: "Sarah Miller"
+excerpt: "Unlock the power of CSS Grid for creating complex, responsive web layouts with ease."
+tags: ["CSS", "Frontend", "Web Design", "Grid Layout"]
+imageUrl: "https://picsum.photos/seed/css-grid-post/800/450"
+---
+
+# A Deep Dive into CSS Grid Layout
+
+CSS Grid Layout is a two-dimensional layout system for the web. It lets you lay content out in rows and columns, and has many features that make building complex layouts straightforward.
+
+## Key Concepts
+
+### Grid Container
+To define a grid container, you set the `display` property of an element to `grid` or `inline-grid`.
+
+```css
+.container {
+  display: grid;
+  grid-template-columns: auto auto auto; /* Defines 3 columns */
+  grid-template-rows: 100px 200px; /* Defines 2 rows */
+  gap: 10px; /* Defines spacing between grid items */
+}
+```
+
+### Grid Items
+Direct children of the grid container automatically become grid items. You can position them explicitly using properties like `grid-column-start`, `grid-column-end`, `grid-row-start`, and `grid-row-end`, or use shorthand properties like `grid-column` and `grid-row`.
+
+```css
+.item-a {
+  grid-column: 1 / 3; /* Span from column line 1 to 3 */
+  grid-row: 1;        /* Place in the first row */
+}
+```
+
+## Why Use CSS Grid?
+
+-   **Two-Dimensional Layouts**: Unlike Flexbox, which is primarily for one-dimensional layouts, Grid excels at managing both rows and columns simultaneously.
+-   **Explicit Placement**: Grid allows precise placement of items, which is excellent for overall page structure.
+-   **Responsive Design**: Combined with media queries, Grid makes it easier to create adaptive layouts for different screen sizes.
+
+CSS Grid is a powerful tool in modern web design. Experiment with its properties to fully grasp its potential for creating sophisticated and responsive web interfaces.

--- a/public/content/posts/getting-started-with-react-hooks.md
+++ b/public/content/posts/getting-started-with-react-hooks.md
@@ -1,0 +1,79 @@
+---
+title: Getting Started with React Hooks
+date: '2024-07-28'
+author: Alex Doe
+excerpt: A comprehensive beginner-friendly guide to understanding and effectively using React Hooks such as useState, useEffect, and more for state management and side effects in functional components.
+tags: React, JavaScript, Frontend, Hooks, State Management
+imageUrl: https://picsum.photos/seed/react-hooks-post/800/450 
+---
+
+# Getting Started with React Hooks
+
+React Hooks, introduced in React 16.8, allow you to use state and other React features without writing a class. They provide a more direct API to the React concepts you already know: props, state, context, refs, and lifecycle.
+
+## Why Hooks?
+
+Hooks solve a wide variety of seemingly unconnected problems in React that we’ve encountered over five years of writing and maintaining tens of thousands of components. 
+- **Reusing stateful logic:** Hooks allow you to extract stateful logic from a component so it can be tested independently and reused.
+- **Complex components become hard to understand:** Hooks let you split one component into smaller functions based on what pieces are related (such as setting up a subscription or fetching data), rather than forcing a split based on lifecycle methods.
+- **Classes confuse both people and machines:** Hooks let you use more of React’s features without classes.
+
+## Basic Hooks
+
+### `useState`
+
+Allows you to add React state to function components.
+
+```javascript
+import React, { useState } from 'react';
+
+function Example() {
+  // Declare a new state variable, which we'll call "count"
+  const [count, setCount] = useState(0);
+
+  return (
+    <div>
+      <p>You clicked {count} times</p>
+      <button onClick={() => setCount(count + 1)}>
+        Click me
+      </button>
+    </div>
+  );
+}
+```
+
+### `useEffect`
+
+Lets you perform side effects in function components. It's a close replacement for `componentDidMount`, `componentDidUpdate`, and `componentWillUnmount` in React classes, but unified into one API.
+
+```javascript
+import React, { useState, useEffect } from 'react';
+
+function FriendStatus(props) {
+  const [isOnline, setIsOnline] = useState(null);
+
+  useEffect(() => {
+    function handleStatusChange(status) {
+      setIsOnline(status.isOnline);
+    }
+    // ChatAPI.subscribeToFriendStatus(props.friend.id, handleStatusChange);
+    // Specify how to clean up after this effect:
+    return function cleanup() {
+      // ChatAPI.unsubscribeFromFriendStatus(props.friend.id, handleStatusChange);
+    };
+  }, []); // If you want to run an effect and clean it up only once (on mount and unmount), you can pass an empty array ([]) as a second argument.
+
+  if (isOnline === null) {
+    return 'Loading...';
+  }
+  return isOnline ? 'Online' : 'Offline';
+}
+```
+(Note: The `ChatAPI` calls in the example above are illustrative and would need a mock or actual implementation to run.)
+
+## Rules of Hooks
+
+- Only call Hooks at the top level. Don’t call Hooks inside loops, conditions, or nested functions.
+- Only call Hooks from React function components. Don’t call Hooks from regular JavaScript functions.
+
+Happy Hooking!

--- a/public/content/posts/graphql-vs-rest-apis.md
+++ b/public/content/posts/graphql-vs-rest-apis.md
@@ -1,0 +1,57 @@
+---
+title: "GraphQL vs. REST: Choosing the Right API Paradigm"
+date: "2024-01-20"
+author: "Emily White"
+excerpt: "A comparative look at GraphQL and REST APIs, helping you decide which approach is best suited for your next project."
+tags: ["GraphQL", "REST", "API", "Web Development", "Backend"]
+imageUrl: "https://picsum.photos/seed/graphql-rest-post/800/450"
+---
+
+# GraphQL vs. REST: Choosing the Right API Paradigm
+
+When building applications that communicate with a server, choosing the right API design paradigm is crucial. REST (Representational State Transfer) has been the de facto standard for years, but GraphQL has emerged as a powerful alternative.
+
+## REST APIs
+
+REST is an architectural style that uses standard HTTP methods (GET, POST, PUT, DELETE) to interact with resources identified by URLs.
+
+**Pros:**
+-   **Simplicity & Familiarity**: Widely understood and based on standard HTTP.
+-   **Caching**: HTTP caching mechanisms can be leveraged effectively.
+-   **Mature Ecosystem**: Vast tooling and community support.
+
+**Cons:**
+-   **Over-fetching/Under-fetching**: Clients often receive more data than needed (over-fetching) or have to make multiple requests to get all required data (under-fetching).
+-   **Versioning**: Managing API versions can be complex.
+-   **Fixed Data Structures**: The server dictates the structure of the response.
+
+## GraphQL
+
+GraphQL is a query language for your API and a server-side runtime for executing those queries. It allows clients to request exactly the data they need and nothing more.
+
+**Pros:**
+-   **No Over-fetching/Under-fetching**: Clients specify precisely what data they need.
+-   **Single Endpoint**: Typically, all requests go to a single endpoint.
+-   **Strongly Typed Schema**: The API is defined by a schema, which serves as a contract between client and server.
+-   **Real-time Updates**: GraphQL subscriptions allow for real-time data.
+
+**Cons:**
+-   **Complexity**: Can be more complex to set up and understand initially compared to simple REST APIs.
+-   **Caching**: Caching is more complex than with REST's HTTP-based caching.
+-   **File Uploads**: Not natively supported in the GraphQL spec; requires workarounds.
+-   **Rate Limiting**: Can be harder to implement granular rate limiting on specific operations.
+
+## When to Choose Which?
+
+-   **REST** is often a good choice for:
+    *   Simple APIs with well-defined resources.
+    *   Public APIs where HTTP caching is a priority.
+    *   Projects where the team is more familiar with REST.
+
+-   **GraphQL** shines for:
+    *   Complex applications with many interconnected data types.
+    *   Mobile applications or clients with limited bandwidth where minimizing data transfer is critical.
+    *   Applications requiring flexible data queries and real-time updates.
+    *   Projects with multiple clients that have different data requirements.
+
+Ultimately, the choice depends on the specific needs of your project, team expertise, and the trade-offs you're willing to make. It's also possible to use both in a microservices architecture.

--- a/public/content/posts/introduction-to-deno-runtime.md
+++ b/public/content/posts/introduction-to-deno-runtime.md
@@ -1,0 +1,48 @@
+---
+title: "An Introduction to Deno: A Secure JavaScript and TypeScript Runtime"
+date: "2024-02-29"
+author: "Kevin Liu"
+excerpt: "Discover Deno, the modern and secure runtime for JavaScript and TypeScript, created by the original author of Node.js."
+tags: ["Deno", "JavaScript", "TypeScript", "Backend", "Node.js"]
+imageUrl: "https://picsum.photos/seed/deno-intro-post/800/450"
+---
+
+# An Introduction to Deno
+
+Deno is a simple, modern, and secure runtime for JavaScript and TypeScript that uses V8 and is built in Rust. It was created by Ryan Dahl, the original creator of Node.js, with the aim to fix some of the design issues in Node.js.
+
+## Key Features
+
+1.  **Secure by Default**: Deno executes code in a sandbox. This means scripts have no access to the file system, network, or environment unless explicitly permitted.
+    ```bash
+    # This script needs explicit permission to access the network
+    deno run --allow-net my_server.ts
+    ```
+
+2.  **TypeScript Support Out of the Box**: Deno treats TypeScript as a first-class language. You don't need to manually configure a TypeScript compiler; Deno handles it internally.
+    ```typescript
+    // example.ts
+    function greet(name: string): string {
+      return `Hello, ${name}!`;
+    }
+    console.log(greet("World"));
+    ```
+    You can run this directly with `deno run example.ts`.
+
+3.  **Standard Modules**: Deno provides a set of audited standard modules (e.g., for file system operations, HTTP servers) that are guaranteed to work with Deno. These are hosted at `deno.land/std`.
+
+4.  **Decentralized Packages**: Deno loads modules via URLs, similar to browsers. There's no centralized package manager like npm.
+    ```typescript
+    import { serve } from "https://deno.land/std@0.200.0/http/server.ts";
+    ```
+
+5.  **Built-in Tooling**: Deno comes with a suite of built-in development tools, including a linter (`deno lint`), formatter (`deno fmt`), test runner (`deno test`), and bundler (`deno bundle`).
+
+## Differences from Node.js
+
+-   No `package.json` or `node_modules` folder. Dependencies are managed via URLs.
+-   Uses ES modules as the default module system (no `require()`).
+-   Explicit permissions for file, network, and environment access.
+-   Aims to be more browser-compatible by providing built-in web APIs like `fetch`.
+
+Deno presents an interesting alternative for JavaScript and TypeScript development, particularly for those prioritizing security and modern language features.

--- a/public/content/posts/mastering-tailwind-css.md
+++ b/public/content/posts/mastering-tailwind-css.md
@@ -1,0 +1,54 @@
+---
+title: Mastering Tailwind CSS for Rapid UI Development
+date: '2024-07-15'
+author: Jane Smith
+excerpt: Explore the power of Tailwind CSS and its utility-first approach to build custom user interfaces with incredible speed and efficiency.
+tags: TailwindCSS, CSS, Frontend, Web Development, UI, UX
+imageUrl: https://picsum.photos/seed/tailwind-post/800/450
+---
+
+# Mastering Tailwind CSS for Rapid UI Development
+
+Tailwind CSS is a utility-first CSS framework packed with classes like `flex`, `pt-4`, `text-center` and `rotate-90` that can be composed to build any design, directly in your markup.
+
+## Core Concepts
+
+### Utility-First
+
+Unlike other CSS frameworks like Bootstrap or Foundation, Tailwind doesn't come with pre-designed components. Instead, it provides low-level utility classes that let you build completely custom designs without ever leaving your HTML.
+
+Example: Building a simple card
+
+```html
+<div class="max-w-sm rounded overflow-hidden shadow-lg bg-white">
+  <img class="w-full" src="https://picsum.photos/seed/tailwind/400/200" alt="Abstract art">
+  <div class="px-6 py-4">
+    <div class="font-bold text-xl mb-2">The Coldest Sunset</div>
+    <p class="text-gray-700 text-base">
+      Lorem ipsum dolor sit amet, consectetur adipisicing elit. Voluptatibus quia, nulla! Maiores et perferendis eaque, exercitationem praesentium nihil.
+    </p>
+  </div>
+  <div class="px-6 pt-4 pb-2">
+    <span class="inline-block bg-gray-200 rounded-full px-3 py-1 text-sm font-semibold text-gray-700 mr-2 mb-2">#photography</span>
+    <span class="inline-block bg-gray-200 rounded-full px-3 py-1 text-sm font-semibold text-gray-700 mr-2 mb-2">#travel</span>
+    <span class="inline-block bg-gray-200 rounded-full px-3 py-1 text-sm font-semibold text-gray-700 mr-2 mb-2">#winter</span>
+  </div>
+</div>
+```
+
+### Responsive Design
+
+Tailwind makes responsive design intuitive. You can apply utilities conditionally at different breakpoints using prefixes like `sm:`, `md:`, `lg:`, `xl:`.
+
+```html
+<img class="w-16 md:w-32 lg:w-48" src="https://picsum.photos/seed/responsive/200/200" alt="Responsive placeholder">
+```
+This image will be `w-16` by default, `w-32` on medium screens and up, and `w-48` on large screens and up.
+
+## Customization
+
+Tailwind is highly customizable. You can configure everything from your color palette to your spacing scale via the `tailwind.config.js` file (or in our case, the inline script in `index.html`). This allows you to create a bespoke design system.
+
+## Conclusion
+
+Tailwind CSS offers a unique and powerful way to build UIs. Its utility-first approach, combined with its customization capabilities, makes it an excellent choice for projects of any size, enabling rapid development and maintainable stylesheets.

--- a/public/content/posts/modern-javascript-es2023-features.md
+++ b/public/content/posts/modern-javascript-es2023-features.md
@@ -1,0 +1,67 @@
+---
+title: "Exploring New Features in Modern JavaScript (ES2023+)"
+date: "2024-04-25"
+author: "David Chen"
+excerpt: "Stay updated with the latest additions to the JavaScript language, enhancing developer productivity and code elegance."
+tags: ["JavaScript", "ESNext", "Web Development", "Programming"]
+imageUrl: "https://picsum.photos/seed/js-es2023-post/800/450"
+---
+
+# Exploring New Features in Modern JavaScript (ES2023+)
+
+JavaScript is constantly evolving, with new features being added regularly to the ECMAScript specification. Staying abreast of these changes can significantly improve your coding practices. Let's look at a couple of notable recent additions.
+
+## `Array.prototype.toSorted()` and similar methods
+
+ES2023 introduced new methods for arrays that return a *new* array with the changes, rather than mutating the original array. This is great for functional programming patterns and working with immutable data structures.
+
+-   `toSorted()`: Returns a new array with the elements sorted.
+-   `toReversed()`: Returns a new array with the elements in reversed order.
+-   `toSpliced(start, deleteCount, ...items)`: Returns a new array with elements removed and/or replaced, similar to `splice()` but non-mutating.
+-   `with(index, value)`: Returns a new array with the element at the given index replaced with the new value.
+
+```javascript
+const originalArray = [3, 1, 4, 1, 5, 9];
+
+const sortedArray = originalArray.toSorted((a, b) => a - b);
+console.log(sortedArray); // [1, 1, 3, 4, 5, 9]
+console.log(originalArray); // [3, 1, 4, 1, 5, 9] (unchanged)
+
+const replacedArray = originalArray.with(1, 100);
+console.log(replacedArray); // [3, 100, 4, 1, 5, 9]
+console.log(originalArray); // [3, 1, 4, 1, 5, 9] (unchanged)
+```
+
+## `Object.groupBy()` and `Map.groupBy()`
+
+This Stage 3 proposal (likely to be part of a future ECMAScript standard) provides a convenient way to group elements of an iterable (like an array) based on a callback function.
+
+```javascript
+const inventory = [
+  { name: "asparagus", type: "vegetables", quantity: 5 },
+  { name: "bananas", type: "fruit", quantity: 0 },
+  { name: "goat", type: "meat", quantity: 23 },
+  { name: "cherries", type: "fruit", quantity: 5 },
+  { name: "fish", type: "meat", quantity: 22 },
+];
+
+// Assuming Object.groupBy is available (e.g., via polyfill or future JS version)
+// const result = Object.groupBy(inventory, ({ type }) => type);
+/*
+result would be:
+{
+  vegetables: [ { name: "asparagus", type: "vegetables", quantity: 5 } ],
+  fruit: [
+    { name: "bananas", type: "fruit", quantity: 0 },
+    { name: "cherries", type: "fruit", quantity: 5 }
+  ],
+  meat: [
+    { name: "goat", type: "meat", quantity: 23 },
+    { name: "fish", type: "meat", quantity: 22 }
+  ]
+}
+*/
+```
+*Note: `Object.groupBy()` might require a polyfill or a very modern JavaScript environment to work as of late 2024.*
+
+Keeping up with these new features allows developers to write more concise, readable, and efficient JavaScript code.

--- a/public/content/posts/optimizing-web-performance-core-web-vitals.md
+++ b/public/content/posts/optimizing-web-performance-core-web-vitals.md
@@ -1,0 +1,37 @@
+---
+title: "Optimizing Web Performance: Understanding Core Web Vitals"
+date: "2023-12-15"
+author: "Brian Green"
+excerpt: "Improve your website's user experience and SEO by understanding and optimizing for Google's Core Web Vitals (LCP, FID, CLS)."
+tags: ["Performance", "Web Vitals", "SEO", "Frontend", "Optimization"]
+imageUrl: "https://picsum.photos/seed/web-vitals-post/800/450"
+---
+
+# Optimizing Web Performance: Understanding Core Web Vitals
+
+Web performance is critical for user experience and search engine optimization (SEO). Google's Core Web Vitals are a set of specific factors that Google considers important in a webpage's overall user experience. They focus on three aspects of the user experience: loading, interactivity, and visual stability.
+
+## The Core Web Vitals
+
+1.  **Largest Contentful Paint (LCP)**: Measures *loading* performance. To provide a good user experience, LCP should occur within **2.5 seconds** of when the page first starts loading.
+    *   LCP marks the point in the page load timeline when the page's main content has likely loaded.
+    *   Common causes of poor LCP: Slow server response times, render-blocking JavaScript and CSS, slow resource loading times (e.g., large images, videos).
+
+2.  **First Input Delay (FID)**: Measures *interactivity*. For a good user experience, pages should have an FID of **100 milliseconds** or less.
+    *   FID measures the time from when a user first interacts with a page (e.g., clicks a link, taps a button) to the time when the browser is actually able to begin processing event handlers in response to that interaction.
+    *   Common causes of poor FID: Heavy JavaScript execution that blocks the main thread.
+
+3.  **Cumulative Layout Shift (CLS)**: Measures *visual stability*. To provide a good user experience, pages should maintain a CLS of **0.1.** or less.
+    *   CLS measures the sum total of all individual layout shift scores for every unexpected layout shift that occurs during the entire lifespan of the page. A layout shift occurs any time a visible element changes its position from one rendered frame to the next.
+    *   Common causes of poor CLS: Images or ads without dimensions, dynamically injected content, web fonts causing FOIT/FOUT.
+
+## Optimizing for Core Web Vitals
+
+-   **Optimize Images**: Compress images, use modern formats (like WebP), and specify image dimensions.
+-   **Reduce Server Response Time**: Optimize server logic, use a CDN, implement caching.
+-   **Minimize Render-Blocking Resources**: Defer non-critical JavaScript and CSS.
+-   **Optimize JavaScript Execution**: Break up long tasks, use web workers.
+-   **Ensure Space for Dynamic Content**: Reserve space for ads or embedded content to prevent layout shifts.
+-   **Preload Key Resources**: Use `<link rel="preload">` for critical assets.
+
+Focusing on Core Web Vitals not only improves user satisfaction but can also positively impact your site's ranking in search results.

--- a/public/content/posts/serverless-architecture-introduction.md
+++ b/public/content/posts/serverless-architecture-introduction.md
@@ -1,0 +1,43 @@
+---
+title: "Introduction to Serverless Architecture: Benefits and Use Cases"
+date: "2023-10-01"
+author: "Michael Black"
+excerpt: "An overview of serverless computing, its advantages like cost-efficiency and scalability, and common use cases."
+tags: ["Serverless", "Cloud Computing", "AWS Lambda", "Azure Functions", "Architecture"]
+imageUrl: "https://picsum.photos/seed/serverless-post/800/450"
+---
+
+# Introduction to Serverless Architecture
+
+Serverless architecture (also known as serverless computing or function as a service, FaaS) is a cloud computing execution model in which the cloud provider dynamically manages the allocation and provisioning of servers. A serverless application runs in stateless compute containers that are event-triggered, ephemeral (may last for one invocation), and fully managed by the cloud provider.
+
+Despite the name "serverless," servers are still used. However, developers are abstracted away from the underlying infrastructure, so they don't need to worry about server provisioning, maintenance, scaling, or capacity planning.
+
+## Key Benefits
+
+1.  **Cost-Efficiency**: You typically pay only for the compute time you consume. If your code isn't running, you're not paying (for compute).
+2.  **Scalability**: The cloud provider automatically scales your application in response to demand. If a function needs to handle thousands of requests per second, the provider will allocate resources accordingly.
+3.  **Reduced Operational Overhead**: Since the cloud provider manages the servers, OS, and runtime, developers can focus more on writing application code and less on infrastructure management.
+4.  **Faster Time to Market**: Developers can build and deploy applications more quickly without being bogged down by server setup and configuration.
+
+## Core Concepts
+
+-   **Functions**: Serverless architectures are often built around small, single-purpose functions.
+-   **Events**: Functions are triggered by events, such as an HTTP request, a new file uploaded to cloud storage, a message in a queue, or a scheduled task.
+-   **Managed Services**: Serverless often involves leveraging other managed services from the cloud provider, such as databases (e.g., DynamoDB, Firestore), storage (e.g., S3, Azure Blob Storage), and authentication services.
+
+## Common Use Cases
+
+-   **Web APIs and Mobile Backends**: Building RESTful or GraphQL APIs.
+-   **Data Processing**: Real-time file processing, stream processing, ETL tasks.
+-   **Chatbots and IoT Applications**: Handling event-driven workloads.
+-   **Scheduled Tasks**: Running cron jobs or other automated tasks.
+
+## Popular Serverless Platforms
+
+-   **AWS Lambda** (Amazon Web Services)
+-   **Azure Functions** (Microsoft Azure)
+-   **Google Cloud Functions** (Google Cloud Platform)
+-   **Cloudflare Workers**
+
+Serverless computing offers a compelling model for building modern applications, especially for event-driven systems and microservices. However, it's not a silver bullet and has its own set of challenges, such as potential for cold starts, vendor lock-in, and debugging complexities.

--- a/public/content/posts/state-management-in-react-beyond-usestate.md
+++ b/public/content/posts/state-management-in-react-beyond-usestate.md
@@ -1,0 +1,82 @@
+---
+title: "State Management in React: Beyond useState and useReducer"
+date: "2023-11-05"
+author: "Olivia Brown"
+excerpt: "Exploring advanced state management solutions in React, including Context API for global state and libraries like Zustand or Jotai."
+tags: ["React", "State Management", "Context API", "Zustand", "Jotai", "Frontend"]
+# No imageUrl for this post page, for variety.
+---
+
+# State Management in React: Beyond `useState` and `useReducer`
+
+For local component state, React's built-in `useState` and `useReducer` hooks are often sufficient. However, as applications grow, managing state that needs to be shared across many components can become challenging. This is where more advanced state management solutions come into play.
+
+## Prop Drilling
+
+One common issue is "prop drilling," where state needs to be passed down through multiple layers of components that don't actually use the state themselves, just to reach a deeply nested component that does. This can make code verbose and hard to maintain.
+
+## React Context API
+
+React's Context API provides a way to pass data through the component tree without having to pass props down manually at every level. It's designed to share data that can be considered "global" for a tree of React components, such as the current authenticated user, theme, or preferred language.
+
+```javascript
+// theme-context.js
+import React, { createContext, useContext, useState } from 'react';
+
+const ThemeContext = createContext();
+
+export function useTheme() {
+  return useContext(ThemeContext);
+}
+
+export function ThemeProvider({ children }) {
+  const [theme, setTheme] = useState('light'); // 'light' or 'dark'
+
+  const toggleTheme = () => {
+    setTheme(prevTheme => (prevTheme === 'light' ? 'dark' : 'light'));
+  };
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+// App.js (or a parent component)
+// import { ThemeProvider } from './theme-context';
+// function App() {
+//   return (
+//     <ThemeProvider>
+//       {/* ... rest of your app ... */}
+//     </ThemeProvider>
+//   );
+// }
+
+// DeeplyNestedComponent.js
+// import { useTheme } from './theme-context';
+// function DeeplyNestedComponent() {
+//   const { theme, toggleTheme } = useTheme();
+//   return (
+//     <div style={{ background: theme === 'light' ? '#fff' : '#333', color: theme === 'light' ? '#000' : '#fff' }}>
+//       Current theme: {theme}
+//       <button onClick={toggleTheme}>Toggle Theme</button>
+//     </div>
+//   );
+// }
+```
+
+While Context is powerful, it can lead to performance issues if not used carefully, as components consuming the context will re-render whenever the context value changes, even if they only care about a small part of that value.
+
+## Third-Party Libraries
+
+For more complex state management needs, or when dealing with frequent updates and performance optimization, developers often turn to dedicated state management libraries.
+
+-   **Redux**: A predictable state container, historically very popular, though often considered verbose for smaller projects.
+-   **Zustand**: A small, fast, and scalable bearbones state-management solution using simplified flux principles. It's known for its simplicity and minimal boilerplate.
+-   **Jotai**: An atomic state management library. State is built up from atoms (small pieces of state), and updates only re-render components that subscribe to the changed atoms.
+-   **Recoil**: An experimental state management library for React by Facebook.
+
+These libraries often offer more advanced features like middleware, developer tools for debugging state changes, and optimized re-rendering.
+
+Choosing the right state management solution depends on the complexity of your application, team familiarity, and performance requirements. Start simple with React's built-in tools and consider more advanced options as your needs evolve.

--- a/public/content/posts/understanding-async-javascript.md
+++ b/public/content/posts/understanding-async-javascript.md
@@ -1,0 +1,102 @@
+---
+title: Understanding Asynchronous JavaScript
+date: '2024-06-20'
+author: Chris Lee
+excerpt: A deep dive into asynchronous programming in JavaScript, covering traditional callbacks, the Promise API, and the modern async/await syntax for non-blocking operations.
+tags: JavaScript, Async, Promises, Callbacks, Web Development, ES6
+# No imageUrl for this post, to show variability.
+---
+
+# Understanding Asynchronous JavaScript
+
+JavaScript is single-threaded, meaning only one operation can be processed at a time. Asynchronous programming allows us to perform long network requests, or other operations that take time, without blocking the main thread and freezing the User Interface.
+
+## 1. Callbacks
+
+The oldest mechanism for handling asynchronous operations. A callback is a function passed as an argument to another function, which is then invoked inside the outer function to complete some kind of routine or action.
+
+```javascript
+function fetchData(callback) {
+  console.log('Fetching data...');
+  setTimeout(() => {
+    const data = { user: 'John Doe', id: 1 };
+    console.log('Data received.');
+    callback(null, data); // error first callback pattern
+  }, 1000);
+}
+
+// fetchData((error, data) => {
+//   if (error) {
+//     console.error('Error:', error);
+//     return;
+//   }
+//   console.log('Data:', data);
+// });
+```
+Callback hell can occur with many nested asynchronous operations, making code hard to read and maintain.
+
+## 2. Promises
+
+Promises provide a cleaner way to handle asynchronous operations. A Promise is an object representing the eventual completion (or failure) of an asynchronous operation and its resulting value.
+
+A Promise is in one of these states:
+- *pending*: initial state, neither fulfilled nor rejected.
+- *fulfilled*: meaning that the operation completed successfully.
+- *rejected*: meaning that the operation failed.
+
+```javascript
+function fetchDataWithPromise() {
+  console.log('Fetching data with Promise...');
+  return new Promise((resolve, reject) => {
+    setTimeout(() => {
+      const success = true; // Math.random() > 0.1; // Usually true for demo
+      if (success) {
+        const data = { user: 'Jane Doe', id: 2 };
+        console.log('Promise resolved.');
+        resolve(data);
+      } else {
+        console.log('Promise rejected.');
+        reject('Failed to fetch data!');
+      }
+    }, 1000);
+  });
+}
+
+// fetchDataWithPromise()
+//   .then(data => {
+//     console.log('Data (Promise):', data);
+//   })
+//   .catch(error => {
+//     console.error('Error (Promise):', error);
+//   });
+```
+
+## 3. Async/Await
+
+Introduced in ES2017, `async/await` is syntactic sugar built on top of Promises, making asynchronous code look and behave a bit more like synchronous code. This makes it easier to read and write.
+
+- `async` keyword before a function makes the function return a Promise.
+- `await` keyword can only be used inside an `async` function. It makes JavaScript wait until that Promise settles and returns its result.
+
+```javascript
+async function fetchDataAsync() {
+  console.log('Fetching data with Async/Await...');
+  try {
+    // Assuming fetchDataWithPromise returns a Promise
+    const data = await fetchDataWithPromise(); 
+    console.log('Data (Async/Await):', data);
+    
+    // Example of awaiting another promise
+    // console.log('Fetching more data...');
+    // const moreData = await anotherAsyncFunction(data.id); // (if anotherAsyncFunction exists)
+    // console.log('More Data:', moreData);
+
+  } catch (error) {
+    console.error('Error (Async/Await):', error);
+  }
+}
+
+// fetchDataAsync();
+```
+
+This modern syntax significantly improves readability and maintainability of asynchronous JavaScript code. Remember to call these example functions (e.g., `fetchDataAsync();`) to see them in action in a JavaScript environment.

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,26 @@
+module.exports = {
+  content: [
+    './app/**/*.{js,ts,jsx,tsx}',
+    './components/**/*.{js,ts,jsx,tsx}',
+  ],
+  theme: {
+    extend: {
+      colors: {
+        primary: {
+          50: '#eff6ff',
+          100: '#dbeafe',
+          200: '#bfdbfe',
+          300: '#93c5fd',
+          400: '#60a5fa',
+          500: '#3b82f6',
+          600: '#2563eb',
+          700: '#1d4ed8',
+          800: '#1e40af',
+          900: '#1e3a8a',
+          950: '#172554',
+        },
+      },
+    },
+  },
+  plugins: [],
+};

--- a/types.ts
+++ b/types.ts
@@ -1,0 +1,18 @@
+
+export interface Post {
+  slug: string;
+  title: string;
+  date: string;
+  author: string;
+  excerpt: string;
+  markdownContent?: string; // Made optional
+  tags: string[];
+  imageUrl?: string; // Optional: URL for the post's featured image
+}
+
+export interface Page {
+  slug: string;
+  title: string;
+  markdownContent?: string;
+  // Add other page-specific front matter fields if needed in the future
+}

--- a/utils/analytics.ts
+++ b/utils/analytics.ts
@@ -1,0 +1,37 @@
+// Declare gtag on the window object
+declare global {
+  interface Window {
+    gtag?: (...args: any[]) => void;
+    dataLayer?: any[];
+  }
+}
+
+export const initGA = (measurementId: string): void => {
+  if (window.gtag && measurementId) {
+    // For GA4, 'anonymize_ip' is true by default and not configurable.
+    window.gtag('config', measurementId);
+    console.log(`Google Analytics (GA4 mode) initialized with Measurement ID: ${measurementId}`);
+  } else {
+    if (!measurementId) console.warn('Google Analytics: Measurement ID is missing.');
+    if (!window.gtag) console.warn('Google Analytics: gtag.js is not loaded.');
+  }
+};
+
+export const sendPageView = (path: string, measurementId: string): void => {
+  if (window.gtag && measurementId) {
+    // For HashRouter, the path from useLocation starts with '/', 
+    // but page_path for GA typically should be the part after #
+    // However, gtag standard is to send the full path including the hash.
+    // So, we can use `window.location.hash.substring(1)` or react-router's `location.pathname`.
+    // Let's stick to path provided by react-router for consistency.
+    window.gtag('event', 'page_view', {
+      page_path: path, // path from react-router, e.g., "/post/my-slug"
+      page_location: window.location.href, // Full URL including hash
+      send_to: measurementId,
+    });
+    // console.log(`Page view sent for: ${path} (GA ID: ${measurementId})`);
+  } else {
+     if (!measurementId) console.warn('Google Analytics: Measurement ID is missing for page view.');
+     // gtag not loaded warning is handled by initGA
+  }
+};

--- a/utils/frontMatterParser.ts
+++ b/utils/frontMatterParser.ts
@@ -1,0 +1,31 @@
+import yaml from 'js-yaml';
+
+export function parseFrontMatter(markdownWithFrontMatter: string): { frontMatter: Record<string, any>, content: string } {
+  let contentToParse = markdownWithFrontMatter;
+  // Strip BOM if present
+  if (contentToParse.startsWith('\uFEFF')) {
+    contentToParse = contentToParse.substring(1);
+  }
+
+  const frontMatterRegex = /^---\s*\n([\s\S]*?)\n---\s*\n([\s\S]*)$/;
+  const match = frontMatterRegex.exec(contentToParse);
+
+  if (match && match[1] && match[2]) {
+    const yamlPart = match[1];
+    const contentPart = match[2];
+    try {
+      // Use js-yaml to parse the front matter. Ensure result is an object.
+      const loadedYaml = yaml.load(yamlPart);
+      const frontMatter = (typeof loadedYaml === 'object' && loadedYaml !== null) ? loadedYaml as Record<string, any> : {};
+      return { frontMatter, content: contentPart.trimStart() };
+    } catch (e: any) {
+      console.error("Error parsing front matter with js-yaml:", e.message);
+      // In case of parsing error, return empty frontMatter and the original content minus the delimiters if possible,
+      // or full content if regex match was problematic.
+      return { frontMatter: {}, content: contentPart.trimStart() || contentToParse };
+    }
+  }
+
+  // No front matter found or regex mismatch, return original content with empty frontMatter
+  return { frontMatter: {}, content: contentToParse };
+}

--- a/utils/postUtils.ts
+++ b/utils/postUtils.ts
@@ -1,0 +1,49 @@
+import { Post } from '../types';
+import { parseFrontMatter } from './frontMatterParser';
+
+// Default values for a post if front matter is incomplete
+const DEFAULT_POST_VALUES: Omit<Post, 'slug' | 'markdownContent'> = {
+  title: 'Untitled Post',
+  date: new Date().toISOString().split('T')[0], // Today's date
+  author: 'Unknown Author',
+  excerpt: 'No excerpt available for this post.',
+  tags: [],
+  imageUrl: undefined,
+};
+
+export async function fetchPostMetadataBySlug(slug: string): Promise<Omit<Post, 'markdownContent'>> {
+  try {
+    const response = await fetch(`/content/posts/${slug}.md`);
+    if (!response.ok) {
+      throw new Error(`File not found or unreadable (status: ${response.status})`);
+    }
+    const rawContent = await response.text();
+    const { frontMatter } = parseFrontMatter(rawContent);
+
+    // Ensure tags are always an array of strings, using what parseFrontMatter provides
+    const tags: string[] = Array.isArray(frontMatter.tags) 
+      ? frontMatter.tags.map(String).filter(tag => tag.trim()) 
+      : (typeof frontMatter.tags === 'string' && frontMatter.tags 
+          ? frontMatter.tags.split(',').map(tag => tag.trim()).filter(tag => tag) 
+          : DEFAULT_POST_VALUES.tags);
+
+    return {
+      slug,
+      title: (frontMatter.title as string) || DEFAULT_POST_VALUES.title,
+      date: (frontMatter.date as string) || DEFAULT_POST_VALUES.date,
+      author: (frontMatter.author as string) || DEFAULT_POST_VALUES.author,
+      excerpt: (frontMatter.excerpt as string) || DEFAULT_POST_VALUES.excerpt,
+      tags: tags.length > 0 ? tags : DEFAULT_POST_VALUES.tags,
+      imageUrl: (frontMatter.imageUrl as string) || DEFAULT_POST_VALUES.imageUrl,
+    };
+  } catch (error: any) {
+    console.error(`Error fetching metadata for slug "${slug}":`, error.message);
+    return {
+      slug,
+      ...DEFAULT_POST_VALUES,
+      title: `Error Loading: ${slug}`,
+      excerpt: `Failed to load metadata for this post. ${error.message || 'Unknown error.'}`,
+      tags: [], // Ensure tags is an empty array on error
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- migrate markdown blog codebase to Next.js app router
- copy blog content and configuration into `public`
- create components, contexts and utilities for Next.js
- add new pages for posts, tags and generic pages
- integrate providers and navigation in layout
- configure Tailwind theme and add required deps

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_68480b8458f48331917d98c05f8b3612