### PR TITLE
Fix eslint img warnings

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,6 +2,7 @@
 "use client";
 
 import React, { useEffect, useState } from 'react';
+import Image from 'next/image';
 import { fetchPostMetadataBySlug } from '../utils/postUtils';
 import PostCard from '../components/PostCard';
 import { Post } from '../types';
@@ -101,10 +102,12 @@ const HomePage: React.FC = () => {
     <div className="container mx-auto px-4 py-8">
       {heroImageUrl && (
         <section className="mb-12 rounded-lg overflow-hidden shadow-xl">
-          <img 
-            src={heroImageUrl} 
-            alt="Blog hero banner" 
-            className="w-full h-auto max-h-[300px] md:max-h-[400px] object-cover" 
+          <Image
+            src={heroImageUrl}
+            alt="Blog hero banner"
+            width={1200}
+            height={400}
+            className="w-full h-auto max-h-[300px] md:max-h-[400px] object-cover"
           />
         </section>
       )}

--- a/app/post/[slug]/page.tsx
+++ b/app/post/[slug]/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useEffect, useState } from 'react';
+import Image from 'next/image';
 import { useParams } from 'next/navigation';
 import Link from 'next/link';
 import { Post } from '../../../types';
@@ -202,10 +203,12 @@ const PostPage: React.FC = () => {
 
         {post.imageUrl && (
           <div className="mb-8 rounded-lg overflow-hidden shadow-lg">
-            <img 
-              src={post.imageUrl} 
-              alt={`Featured image for ${post.title}`} 
-              className="w-full h-auto max-h-[500px] object-cover" 
+            <Image
+              src={post.imageUrl}
+              alt={`Featured image for ${post.title}`}
+              width={1200}
+              height={500}
+              className="w-full h-auto max-h-[500px] object-cover"
             />
           </div>
         )}

--- a/components/PostCard.tsx
+++ b/components/PostCard.tsx
@@ -3,6 +3,7 @@
 
 import Link from 'next/link';
 import React from 'react';
+import Image from 'next/image';
 import { Post } from '../types';
 
 interface PostCardProps {
@@ -14,12 +15,16 @@ const PostCard: React.FC<PostCardProps> = ({ post }) => {
     <article className="bg-white rounded-lg shadow-lg overflow-hidden transition-shadow hover:shadow-xl duration-300 flex flex-col">
       {post.imageUrl && (
         <Link href={`/post/${post.slug}`} aria-hidden="true" tabIndex={-1}>
-          <img 
-            src={post.imageUrl} 
-            alt={`Featured image for ${post.title}`} 
-            className="w-full h-48 object-cover" 
-            loading="lazy"
-          />
+          <div className="relative w-full h-48">
+            <Image
+              src={post.imageUrl}
+              alt={`Featured image for ${post.title}`}
+              fill
+              className="object-cover"
+              sizes="(max-width: 640px) 100vw, 33vw"
+              priority={false}
+            />
+          </div>
         </Link>
       )}
       <div className="p-6 flex flex-col flex-grow">


### PR DESCRIPTION
## Summary
- replace plain `img` tags with optimized `<Image>` from Next.js

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_6848295ac0248331a3aeb04733ee13b5