### PR TITLE
Fix theme variables for Tailwind 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,13 @@ You can start editing the page by modifying `app/page.tsx`. The page auto-update
 
 This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
 
+## Tailwind CSS
+
+Tailwind CSS v4 is enabled using the `@tailwindcss/postcss` plugin. Global theme
+variables are defined in `app/globals.css` as standard CSS variables and mirror
+the palette in `tailwind.config.js`. If you update the palette, update these
+variables as well.
+
 ## Learn More
 
 To learn more about Next.js, take a look at the following resources:

--- a/app/globals.css
+++ b/app/globals.css
@@ -3,11 +3,19 @@
 :root {
   --background: #ffffff;
   --foreground: #171717;
-}
-
-@theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
+  --color-primary-50: #eff6ff;
+  --color-primary-100: #dbeafe;
+  --color-primary-200: #bfdbfe;
+  --color-primary-300: #93c5fd;
+  --color-primary-400: #60a5fa;
+  --color-primary-500: #3b82f6;
+  --color-primary-600: #2563eb;
+  --color-primary-700: #1d4ed8;
+  --color-primary-800: #1e40af;
+  --color-primary-900: #1e3a8a;
+  --color-primary-950: #172554;
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
 }


### PR DESCRIPTION
## Summary
- use plain CSS variables in `globals.css` rather than `@theme inline`
- document Tailwind setup and theme variables in README

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch fonts)*

------
https://chatgpt.com/codex/tasks/task_b_684890c71ed8833190a9f17a9d90c88b