### PR TITLE
Add usage instructions for markdown blog

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,36 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+
+## Blog Content Structure
+
+Markdown files in `public/content` drive the blog:
+
+- `public/content/posts` - individual blog posts. Each file name becomes the URL slug and must contain YAML front matter (see existing posts for examples).
+- `public/content/pages` - static pages such as `about.md`.
+- `public/config.yml` - site-wide values like the blog title and hero image.
+
+## Building and Exporting
+
+Run the build command to create the static site:
+
+```bash
+npm run build
+```
+
+`next.config.ts` sets `output: 'export'`, so `next build` automatically runs `next export` and produces the static files in the `out` directory. If you remove that option you must run `next export` after the build.
+
+## Adding Posts and Pages
+
+1. Create a new Markdown file in `public/content/posts` (or `public/content/pages`).
+2. Include the front matter fields (`title`, `date`, `author`, etc.).
+3. Update any global settings in `public/config.yml` if needed.
+
+## Commit Workflow
+
+Before committing, run ESLint and fix any issues:
+
+```bash
+npm run lint
+```
+


### PR DESCRIPTION
## Summary
- document the markdown-based content layout and how to add posts
- explain building the static export with `npm run build`
- instruct to run eslint before committing

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font `Geist`)*

------
https://chatgpt.com/codex/tasks/task_b_684aa25f7b9c833183dde2f03b8b6d7a