### PR TITLE
Fix Next.js dynamic page props

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -8,8 +8,8 @@
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
+  --font-sans: system-ui, Arial, sans-serif;
+  --font-mono: ui-monospace, SFMono-Regular, Menlo, monospace;
 }
 
 @media (prefers-color-scheme: dark) {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import Link from "next/link";
 import Navbar from "../components/Navbar";
@@ -8,15 +7,6 @@ import AnalyticsRouteChangeTracker from "../components/AnalyticsRouteChangeTrack
 import { SiteConfigProvider } from "../contexts/SiteConfigContext";
 import { CookieConsentProvider } from "../contexts/CookieConsentContext";
 
-const geistSans = Geist({
-  variable: "--font-geist-sans",
-  subsets: ["latin"],
-});
-
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
-  subsets: ["latin"],
-});
 
 export const metadata: Metadata = {
   title: "Create Next App",
@@ -30,7 +20,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
+      <body className="antialiased">
         <SiteConfigProvider>
           <CookieConsentProvider>
             <div className="flex flex-col min-h-screen">

--- a/app/page/[slug]/page.tsx
+++ b/app/page/[slug]/page.tsx
@@ -20,11 +20,11 @@ export async function generateStaticParams() {
 }
 
 interface PageProps {
-  params: { slug: string };
+  params: Promise<{ slug: string }>;
 }
 
 const GenericPage = async ({ params }: PageProps) => {
-  const slug = params.slug;
+  const { slug } = await params;
   const filePath = path.join(process.cwd(), 'public', 'content', 'pages', `${slug}.md`);
 
   try {

--- a/app/post/[slug]/page.tsx
+++ b/app/post/[slug]/page.tsx
@@ -33,7 +33,7 @@ const EmailIcon: React.FC<{ className?: string }> = ({ className = "h-5 w-5" }) 
 );
 
 interface PageProps {
-  params: { slug: string };
+  params: Promise<{ slug: string }>;
 }
 
 const DEFAULT_POST_PAGE_VALUES: Omit<Post, 'slug'> = {
@@ -93,7 +93,8 @@ export async function generateStaticParams() {
 }
 
 const PostPage = async ({ params }: PageProps) => {
-  const post = await getPostData(params.slug);
+  const { slug } = await params;
+  const post = await getPostData(slug);
 
   const postUrl = `/post/${post.slug}`;
   const encodedPostUrl = encodeURIComponent(postUrl);

--- a/app/tags/[tagName]/page.tsx
+++ b/app/tags/[tagName]/page.tsx
@@ -7,7 +7,7 @@ import { Post } from '../../../types';
 import { parseFrontMatter } from '../../../utils/frontMatterParser';
 
 interface PageProps {
-  params: { tagName: string };
+  params: Promise<{ tagName: string }>;
 }
 
 const DEFAULT_POST_VALUES: Omit<Post, 'slug' | 'markdownContent'> = {
@@ -68,10 +68,11 @@ export async function generateStaticParams() {
 }
 
 const PostsByTagPage = async ({ params }: PageProps) => {
-  const tagName = decodeURIComponent(params.tagName);
+  const { tagName } = await params;
+  const decodedTag = decodeURIComponent(tagName);
   const posts = await getAllPostsMetadata();
   const postsForTag = posts.filter(post =>
-    post.tags.map(t => t.toLowerCase()).includes(tagName.toLowerCase())
+    post.tags.map(t => t.toLowerCase()).includes(decodedTag.toLowerCase())
   );
   const sortedPosts = postsForTag.sort(
     (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime()
@@ -81,7 +82,7 @@ const PostsByTagPage = async ({ params }: PageProps) => {
     <div className="container mx-auto px-4 py-8">
       <header className="mb-10">
         <h1 className="text-4xl font-bold text-primary-800 mb-2">
-          Posts tagged with: <span className="text-primary-600">{tagName || 'Unknown Tag'}</span>
+          Posts tagged with: <span className="text-primary-600">{decodedTag || 'Unknown Tag'}</span>
         </h1>
         <Link
           href="/tags"


### PR DESCRIPTION
## Summary
- use system fonts instead of downloading Google fonts
- adjust Next.js page components to use promised params

## Testing
- `npm run lint`
- `npm run build` *(fails: Error: export const dynamic / revalidate not configured for /api/post-slugs)*

------
https://chatgpt.com/codex/tasks/task_b_684aa5880b308331a50cf8336bd2d9a0