### PR TITLE
Fix export build by marking API route as static

### DIFF
--- a/app/api/post-slugs/route.ts
+++ b/app/api/post-slugs/route.ts
@@ -2,6 +2,12 @@ import { NextResponse } from 'next/server';
 import fs from 'fs';
 import path from 'path';
 
+// When building the app for static export, Next.js requires API routes
+// to opt into static generation. Setting `dynamic` to "force-static" makes
+// this route run at build time so the resulting JSON file can be served
+// without a Node.js runtime.
+export const dynamic = 'force-static';
+
 export async function GET() {
   try {
     const postsDir = path.join(process.cwd(), 'public', 'content', 'posts');


### PR DESCRIPTION
## Summary
- mark `post-slugs` API route as static so Next.js can export it

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_684aa8e209608331b04f541cc551e99f