### PR TITLE
Fix basePath for fetching site data

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -24,7 +24,8 @@ const HomePage: React.FC = () => {
       setIsLoadingPosts(true);
       setPostsError(null);
       try {
-        const manifestResponse = await fetch('/api/post-slugs');
+        const basePath = process.env.NEXT_PUBLIC_BASE_PATH || '';
+        const manifestResponse = await fetch(`${basePath}/api/post-slugs`);
         if (!manifestResponse.ok) {
           throw new Error(`Failed to fetch post list: ${manifestResponse.statusText} (status ${manifestResponse.status})`);
         }

--- a/app/tags/page.tsx
+++ b/app/tags/page.tsx
@@ -17,7 +17,8 @@ const TagsPage: React.FC = () => {
       setIsLoading(true);
       setError(null);
       try {
-        const manifestResponse = await fetch('/api/post-slugs');
+        const basePath = process.env.NEXT_PUBLIC_BASE_PATH || '';
+        const manifestResponse = await fetch(`${basePath}/api/post-slugs`);
         if (!manifestResponse.ok) {
           throw new Error(`Failed to fetch post list: ${manifestResponse.statusText} (status ${manifestResponse.status})`);
         }

--- a/contexts/SiteConfigContext.tsx
+++ b/contexts/SiteConfigContext.tsx
@@ -35,7 +35,8 @@ export const SiteConfigProvider: React.FC<{ children: ReactNode }> = ({ children
   useEffect(() => {
     const fetchConfig = async () => {
       try {
-        const response = await fetch('/config.yml');
+        const basePath = process.env.NEXT_PUBLIC_BASE_PATH || '';
+        const response = await fetch(`${basePath}/config.yml`);
         if (!response.ok) {
           throw new Error(`Failed to fetch config.yml: ${response.statusText} (status: ${response.status})`);
         }

--- a/next.config.ts
+++ b/next.config.ts
@@ -4,6 +4,9 @@ const nextConfig: NextConfig = {
   /* config options here */
   basePath: '/react-next-blog',
   output: 'export',
+  env: {
+    NEXT_PUBLIC_BASE_PATH: '/react-next-blog',
+  },
 };
 
 export default nextConfig;

--- a/utils/postUtils.ts
+++ b/utils/postUtils.ts
@@ -13,7 +13,8 @@ const DEFAULT_POST_VALUES: Omit<Post, 'slug' | 'markdownContent'> = {
 
 export async function fetchPostMetadataBySlug(slug: string): Promise<Omit<Post, 'markdownContent'>> {
   try {
-    const response = await fetch(`/content/posts/${slug}.md`);
+    const basePath = process.env.NEXT_PUBLIC_BASE_PATH || '';
+    const response = await fetch(`${basePath}/content/posts/${slug}.md`);
     if (!response.ok) {
       throw new Error(`File not found or unreadable (status: ${response.status})`);
     }


### PR DESCRIPTION
## Summary
- add NEXT_PUBLIC_BASE_PATH env setting in Next config
- reference NEXT_PUBLIC_BASE_PATH when fetching config.yml
- reference NEXT_PUBLIC_BASE_PATH when fetching post slugs and posts

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_684aaad261948331aa06a2c4e3bf7a9c