### PR TITLE
Fix asset paths for GitHub Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ npm run build
 
 `next.config.ts` sets `output: 'export'`, so `next build` automatically runs `next export` and produces the static files in the `out` directory. If you remove that option you must run `next export` after the build.
 
+The configuration also sets `basePath` and `assetPrefix` to `/react-next-blog` and disables image optimization (`images.unoptimized = true`) so the exported files work when hosted on GitHub Pages.
+
 ## Adding Posts and Pages
 
 1. Create a new Markdown file in `public/content/posts` (or `public/content/pages`).

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,11 +1,18 @@
 import type { NextConfig } from "next";
 
+const isProd = process.env.NODE_ENV === "production";
+
 const nextConfig: NextConfig = {
   /* config options here */
-  basePath: '/react-next-blog',
-  output: 'export',
+  basePath: "/react-next-blog",
+  assetPrefix: isProd ? "/react-next-blog/" : undefined,
+  images: {
+    // GitHub Pages can't handle dynamic image optimization
+    unoptimized: true,
+  },
+  output: "export",
   env: {
-    NEXT_PUBLIC_BASE_PATH: '/react-next-blog',
+    NEXT_PUBLIC_BASE_PATH: "/react-next-blog",
   },
 };
 


### PR DESCRIPTION
## Summary
- configure `assetPrefix` and disable image optimization for GitHub Pages
- document the production configuration settings

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_684aaf8d9cb8833197bf3876d89e6840