### PR TITLE
Fix static asset paths for GitHub Pages

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -61,7 +61,11 @@ const HomePage: React.FC = () => {
     loadPosts();
   }, []);
 
-  const heroImageUrl = isConfigLoading || configError ? null : config.homepageHeroImageUrl;
+  const basePath = process.env.NEXT_PUBLIC_BASE_PATH || '';
+  const rawHeroImage = isConfigLoading || configError ? null : config.homepageHeroImageUrl;
+  const heroImageUrl = rawHeroImage && !rawHeroImage.startsWith('http')
+    ? `${basePath}${rawHeroImage}`
+    : rawHeroImage;
 
   // Pagination logic
   const indexOfLastPost = currentPage * POSTS_PER_PAGE;

--- a/components/PostCard.tsx
+++ b/components/PostCard.tsx
@@ -11,13 +11,19 @@ interface PostCardProps {
 }
 
 const PostCard: React.FC<PostCardProps> = ({ post }) => {
+  const basePath = process.env.NEXT_PUBLIC_BASE_PATH || '';
+  const imageSrc =
+    post.imageUrl && !post.imageUrl.startsWith('http')
+      ? `${basePath}${post.imageUrl}`
+      : post.imageUrl;
+
   return (
     <article className="bg-white rounded-lg shadow-lg overflow-hidden transition-shadow hover:shadow-xl duration-300 flex flex-col">
       {post.imageUrl && (
         <Link href={`/post/${post.slug}`} aria-hidden="true" tabIndex={-1}>
           <div className="relative w-full h-48">
             <Image
-              src={post.imageUrl}
+              src={imageSrc as string}
               alt={`Featured image for ${post.title}`}
               fill
               className="object-cover"


### PR DESCRIPTION
## Summary
- prefix image URLs with the configured base path
- compute hero image path using NEXT_PUBLIC_BASE_PATH

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_684ab38dff788331b2340764b89e25b9