### PR TITLE
Implement cookie consent analytics loader

### DIFF
--- a/app/head.tsx
+++ b/app/head.tsx
@@ -1,0 +1,12 @@
+export default function Head() {
+  return (
+    <>
+      <script
+        id="ga-stub"
+        dangerouslySetInnerHTML={{
+          __html: `window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}gtag('consent','default',{'analytics_storage':'denied'});`,
+        }}
+      />
+    </>
+  );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,9 +1,10 @@
 import type { Metadata } from "next";
 import "./globals.css";
-import Link from "next/link";
 import Navbar from "../components/Navbar";
 import CookieConsentBanner from "../components/CookieConsentBanner";
 import AnalyticsRouteChangeTracker from "../components/AnalyticsRouteChangeTracker";
+import GoogleAnalyticsLoader from "../components/GoogleAnalyticsLoader";
+import Footer from "../components/Footer";
 import { SiteConfigProvider } from "../contexts/SiteConfigContext";
 import { CookieConsentProvider } from "../contexts/CookieConsentContext";
 
@@ -27,18 +28,11 @@ export default function RootLayout({
               <Navbar />
               <main className="flex-grow bg-gray-100 py-8">
                 <AnalyticsRouteChangeTracker />
+                <GoogleAnalyticsLoader />
                 {children}
               </main>
               <CookieConsentBanner />
-              <footer className="bg-primary-800 text-primary-100 text-center p-6 shadow-inner">
-                <p>&copy; {new Date().getFullYear()} React Markdown Blog. All rights reserved.</p>
-                <p className="text-sm mt-1">
-                  Powered by React, Tailwind CSS, and your Markdown! |{' '}
-                  <Link href="/page/privacy-policy" className="underline hover:text-primary-300">
-                    Informativa Privacy e Cookie Policy
-                  </Link>
-                </p>
-              </footer>
+              <Footer />
             </div>
           </CookieConsentProvider>
         </SiteConfigProvider>

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import Link from "next/link";
+import { useCookieConsent } from "../contexts/CookieConsentContext";
+
+const Footer: React.FC = () => {
+  const { openBanner } = useCookieConsent();
+
+  return (
+    <footer className="bg-primary-800 text-primary-100 text-center p-6 shadow-inner">
+      <p>&copy; {new Date().getFullYear()} React Markdown Blog. All rights reserved.</p>
+      <p className="text-sm mt-1">
+        Powered by React, Tailwind CSS, and your Markdown!{' '}
+        <Link href="/page/privacy-policy" className="underline hover:text-primary-300">
+          Informativa Privacy e Cookie Policy
+        </Link>
+      </p>
+      <button
+        onClick={openBanner}
+        className="mt-2 underline text-sm hover:text-primary-300 focus:outline-none"
+        aria-label="Gestisci preferenze cookie"
+      >
+        Gestisci preferenze cookie
+      </button>
+    </footer>
+  );
+};
+
+export default Footer;

--- a/components/GoogleAnalyticsLoader.tsx
+++ b/components/GoogleAnalyticsLoader.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { useEffect } from 'react';
+import { useCookieConsent } from '../contexts/CookieConsentContext';
+import { useSiteConfig } from '../contexts/SiteConfigContext';
+import { initGA } from '../utils/analytics';
+
+const GoogleAnalyticsLoader: React.FC = () => {
+  const { consentGiven } = useCookieConsent();
+  const { config: siteConfig, isLoading } = useSiteConfig();
+
+  useEffect(() => {
+    if (consentGiven && !isLoading && siteConfig.gaMeasurementId) {
+      if (!document.getElementById('ga-script')) {
+        const script = document.createElement('script');
+        script.id = 'ga-script';
+        script.async = true;
+        script.src = `https://www.googletagmanager.com/gtag/js?id=${siteConfig.gaMeasurementId}`;
+        document.head.appendChild(script);
+
+        const init = document.createElement('script');
+        init.id = 'ga-init';
+        init.innerHTML = `window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}gtag('js', new Date());`;
+        document.head.appendChild(init);
+      }
+
+      if (window.gtag) {
+        initGA(siteConfig.gaMeasurementId);
+      }
+    }
+  }, [consentGiven, isLoading, siteConfig.gaMeasurementId]);
+
+  return null;
+};
+
+export default GoogleAnalyticsLoader;

--- a/contexts/CookieConsentContext.tsx
+++ b/contexts/CookieConsentContext.tsx
@@ -9,6 +9,7 @@ interface CookieConsentContextType {
   showBanner: boolean;
   giveConsent: () => void;
   declineConsent: () => void;
+  openBanner: () => void;
 }
 
 const CookieConsentContext = createContext<CookieConsentContextType | undefined>(undefined);
@@ -75,10 +76,16 @@ export const CookieConsentProvider: React.FC<{ children: ReactNode }> = ({ child
     setConsentGiven(false);
     setShowBanner(false);
     localStorage.setItem('cookieConsent', 'false');
+    document.getElementById('ga-script')?.remove();
+    document.getElementById('ga-init')?.remove();
+  };
+
+  const openBanner = () => {
+    setShowBanner(true);
   };
 
   return (
-    <CookieConsentContext.Provider value={{ consentGiven, showBanner, giveConsent, declineConsent }}>
+    <CookieConsentContext.Provider value={{ consentGiven, showBanner, giveConsent, declineConsent, openBanner }}>
       {children}
     </CookieConsentContext.Provider>
   );


### PR DESCRIPTION
## Summary
- load Google Analytics dynamically only after user consent
- preload GA stub with denied consent by default
- add footer with cookie preferences button
- manage banner opening through context

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_684ff00e8a40833190e30de837d8d537