### PR TITLE
Fix CSS import order for Tailwind 4

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,5 +1,8 @@
-@import "tailwindcss";
 @import url("https://fonts.googleapis.com/css2?family=Newsreader:wght@400;500;700;800&family=Noto+Sans:wght@400;500;700;900&display=swap");
+
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
 
 :root {
   --primary-color: #3b82f6;


### PR DESCRIPTION
## Summary
- ensure font import is first
- use Tailwind directives in globals.css

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_6852734c587c8331b44978c038a7262e