### PR TITLE
Style home page like provided mockup

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,8 +1,8 @@
 @import "tailwindcss";
 
 :root {
-  --background: #1E40AF;
-  --foreground: #171717;
+  --background: #ffffff;
+  --foreground: #111418;
 }
 
 @theme inline {
@@ -22,7 +22,7 @@
 body {
   background: var(--background);
   color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: 'Newsreader', 'Noto Sans', sans-serif;
 }
 
 

--- a/app/head.tsx
+++ b/app/head.tsx
@@ -1,6 +1,11 @@
 export default function Head() {
   return (
     <>
+      <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="" />
+      <link
+        rel="stylesheet"
+        href="https://fonts.googleapis.com/css2?display=swap&family=Newsreader:wght@400;500;700;800&family=Noto+Sans:wght@400;500;700;900"
+      />
       <script
         id="ga-stub"
         dangerouslySetInnerHTML={{

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -104,73 +104,81 @@ const HomePage: React.FC = () => {
   }
 
   return (
-    <div className="container mx-auto px-4 py-8">
-      {heroImageUrl && (
-        <section className="mb-12 rounded-lg overflow-hidden shadow-xl">
-          <Image
-            src={heroImageUrl}
-            alt="Blog hero banner"
-            width={1200}
-            height={400}
-            className="w-full h-auto max-h-[300px] md:max-h-[400px] object-cover"
-          />
-        </section>
-      )}
+    <div className="px-6 md:px-20 flex justify-center py-5">
+      <div className="flex flex-col max-w-[960px] w-full">
+        {heroImageUrl && (
+          <section className="mb-6 relative rounded-lg overflow-hidden min-h-[218px] @container">
+            <Image
+              src={heroImageUrl}
+              alt="Blog hero banner"
+              fill
+              className="object-cover"
+              sizes="(max-width: 768px) 100vw, 960px"
+              priority={false}
+            />
+            <div className="absolute inset-0 bg-gradient-to-t from-black/40 to-transparent" />
+            <div className="relative flex p-4">
+              <p className="text-white tracking-light text-[28px] font-bold leading-tight">Welcome to the Blog</p>
+            </div>
+          </section>
+        )}
 
-      <header className="mb-12 text-center">
-        <h1 className="text-5xl font-extrabold text-primary-800">Welcome to the Blog</h1>
-        <p className="text-xl text-gray-600 mt-2">Discover insights and stories on web development, technology, and more.</p>
-      </header>
-      
-      {currentPosts.length > 0 ? (
-        <>
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
+        <header className="mb-8 text-center">
+          <p className="text-brand-muted text-base">Discover insights and stories on web development, technology, and more.</p>
+        </header>
+
+        {currentPosts.length > 0 ? (
+          <>
             {currentPosts.map(post => (
-              <PostCard key={post.slug} post={post as Post} /> 
+              <div key={post.slug} className="p-4">
+                <PostCard post={post as Post} />
+              </div>
             ))}
-          </div>
-          {totalPages > 1 && (
-            <nav aria-label="Posts pagination" className="mt-12 flex justify-center items-center space-x-2">
-              <button
-                onClick={() => paginate(currentPage - 1)}
-                disabled={currentPage === 1}
-                className="px-4 py-2 bg-primary-600 text-white rounded hover:bg-primary-700 disabled:bg-gray-300 disabled:cursor-not-allowed transition-colors"
-                aria-label="Previous page"
-              >
-                &larr; Previous
-              </button>
-              {pageNumbers.map(number => (
+            {totalPages > 1 && (
+              <nav aria-label="Posts pagination" className="mt-4 flex items-center justify-center gap-1">
                 <button
-                  key={number}
-                  onClick={() => paginate(number)}
-                  className={`px-4 py-2 rounded transition-colors ${
-                    currentPage === number
-                      ? 'bg-primary-800 text-white font-bold ring-2 ring-primary-500'
-                      : 'bg-primary-200 text-primary-700 hover:bg-primary-300'
-                  }`}
-                  aria-current={currentPage === number ? "page" : undefined}
-                  aria-label={`Go to page ${number}`}
+                  onClick={() => paginate(currentPage - 1)}
+                  disabled={currentPage === 1}
+                  className="flex size-10 items-center justify-center disabled:text-gray-300"
+                  aria-label="Previous page"
                 >
-                  {number}
+                  <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="currentColor" viewBox="0 0 256 256">
+                    <path d="M165.66,202.34a8,8,0,0,1-11.32,11.32l-80-80a8,8,0,0,1,0-11.32l80-80a8,8,0,0,1,11.32,11.32L91.31,128Z"></path>
+                  </svg>
                 </button>
-              ))}
-              <button
-                onClick={() => paginate(currentPage + 1)}
-                disabled={currentPage === totalPages}
-                className="px-4 py-2 bg-primary-600 text-white rounded hover:bg-primary-700 disabled:bg-gray-300 disabled:cursor-not-allowed transition-colors"
-                aria-label="Next page"
-              >
-                Next &rarr;
-              </button>
-            </nav>
-          )}
-        </>
-      ) : (
-        <div className="text-center py-12">
-          <h2 className="text-2xl font-semibold text-gray-700">No posts yet!</h2>
-          <p className="text-gray-500 mt-2">Check back soon for new content, or ensure the post manifest file is configured if posts exist.</p>
-        </div>
-      )}
+                {pageNumbers.map(number => (
+                  <button
+                    key={number}
+                    onClick={() => paginate(number)}
+                    className={`text-sm flex size-10 items-center justify-center rounded-full ${
+                      currentPage === number ? 'font-bold bg-brand-light' : ''
+                    }`}
+                    aria-current={currentPage === number ? 'page' : undefined}
+                    aria-label={`Go to page ${number}`}
+                  >
+                    {number}
+                  </button>
+                ))}
+                <button
+                  onClick={() => paginate(currentPage + 1)}
+                  disabled={currentPage === totalPages}
+                  className="flex size-10 items-center justify-center disabled:text-gray-300"
+                  aria-label="Next page"
+                >
+                  <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="currentColor" viewBox="0 0 256 256">
+                    <path d="M181.66,133.66l-80,80a8,8,0,0,1-11.32-11.32L164.69,128,90.34,53.66a8,8,0,0,1,11.32-11.32l80,80A8,8,0,0,1,181.66,133.66Z"></path>
+                  </svg>
+                </button>
+              </nav>
+            )}
+          </>
+        ) : (
+          <div className="text-center py-12">
+            <h2 className="text-2xl font-semibold text-gray-700">No posts yet!</h2>
+            <p className="text-gray-500 mt-2">Check back soon for new content, or ensure the post manifest file is configured if posts exist.</p>
+          </div>
+        )}
+      </div>
     </div>
   );
 };

--- a/components/PostCard.tsx
+++ b/components/PostCard.tsx
@@ -2,8 +2,8 @@
 "use client";
 
 import Link from 'next/link';
-import React from 'react';
 import Image from 'next/image';
+import React from 'react';
 import { Post } from '../types';
 import slugify from '../utils/slugify';
 
@@ -19,52 +19,47 @@ const PostCard: React.FC<PostCardProps> = ({ post }) => {
       : post.imageUrl;
 
   return (
-    <article className="bg-white rounded-lg shadow-lg overflow-hidden transition-shadow hover:shadow-xl duration-300 flex flex-col">
-      {post.imageUrl && (
-        <Link href={`/post/${post.slug}`} aria-hidden="true" tabIndex={-1}>
-          <div className="relative w-full h-48">
-            <Image
-              src={imageSrc as string}
-              alt={`Featured image for ${post.title}`}
-              fill
-              className="object-cover"
-              sizes="(max-width: 640px) 100vw, 33vw"
-              priority={false}
-            />
-          </div>
-        </Link>
-      )}
-      <div className="p-6 flex flex-col flex-grow">
-        <h2 className="text-2xl font-bold text-primary-700 mb-2">
-          <Link href={`/post/${post.slug}`} className="hover:underline">
-            {post.title}
-          </Link>
-        </h2>
-        <div className="text-sm text-gray-500 mb-3">
-          <span>By {post.author}</span> | <span>{new Date(post.date).toLocaleDateString()}</span>
-        </div>
-        <p className="text-gray-700 mb-4 leading-relaxed flex-grow">{post.excerpt}</p>
-        <div className="mb-4">
+    <article className="flex flex-col md:flex-row items-stretch justify-between gap-4 rounded-lg">
+      <div className="flex flex-col gap-4 flex-[2_2_0px]">
+        <div className="flex flex-wrap gap-2">
           {post.tags.map(tag => (
             <Link
               key={tag}
               href={`/tags/${slugify(tag)}`}
-              className="inline-block bg-primary-100 text-primary-700 text-xs font-semibold mr-2 mb-2 px-2.5 py-0.5 rounded-full hover:bg-primary-200 hover:text-primary-800 transition-colors duration-200"
+              className="inline-block bg-primary-100 text-primary-700 text-xs font-semibold px-2.5 py-0.5 rounded-full hover:bg-primary-200 hover:text-primary-800 transition-colors duration-200"
               aria-label={`View posts tagged with ${tag}`}
             >
               {tag}
             </Link>
           ))}
         </div>
-        <div className="mt-auto">
+        <h2 className="text-brand-dark text-base md:text-lg font-bold leading-tight">
+          <Link href={`/post/${post.slug}`}>{post.title}</Link>
+        </h2>
+        <p className="text-brand-muted text-sm leading-normal flex-grow">{post.excerpt}</p>
+        <div>
           <Link
             href={`/post/${post.slug}`}
-            className="inline-block bg-primary-600 text-white font-semibold px-4 py-2 rounded hover:bg-primary-700 transition-colors duration-300"
+            className="flex min-w-[84px] max-w-[480px] items-center justify-center h-8 px-4 bg-brand-light text-brand-dark text-sm font-medium rounded-lg w-fit"
           >
-            Read More &rarr;
+            <span className="truncate">Read More</span>
           </Link>
         </div>
       </div>
+      {post.imageUrl && (
+        <Link href={`/post/${post.slug}`} className="w-full md:flex-1" aria-hidden="true" tabIndex={-1}>
+          <div className="relative w-full aspect-video rounded-lg overflow-hidden">
+            <Image
+              src={imageSrc as string}
+              alt={`Featured image for ${post.title}`}
+              fill
+              className="object-cover"
+              sizes="(max-width: 768px) 100vw, 50vw"
+              priority={false}
+            />
+          </div>
+        </Link>
+      )}
     </article>
   );
 };

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -5,7 +5,16 @@ module.exports = {
   ],
   theme: {
     extend: {
+      fontFamily: {
+        sans: ['"Noto Sans"', 'sans-serif'],
+        newsreader: ['Newsreader', 'serif'],
+      },
       colors: {
+        brand: {
+          dark: '#111418',
+          muted: '#60748a',
+          light: '#f0f2f5',
+        },
         primary: {
           50: '#eff6ff',
           100: '#dbeafe',


### PR DESCRIPTION
## Summary
- import new Google fonts and apply fonts globally
- tweak Tailwind config for fonts
- restyle PostCard to match horizontal layout with responsive design
- restyle home page hero, list layout and pagination
- centralize theme colors and restore Next.js `Image` usage

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68527cf3f2f48331bda5707c26671e7f