### PR TITLE
Implement Inter font integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Open [http://localhost:3000](http://localhost:3000) with your browser to see the
 
 You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load the [Inter](https://rsms.me/inter/) font.
 
 ## Learn More
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -8,7 +8,7 @@
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans: system-ui, Arial, sans-serif;
+  --font-sans: var(--font-inter), system-ui, Arial, sans-serif;
   --font-mono: ui-monospace, SFMono-Regular, Menlo, monospace;
 }
 
@@ -22,7 +22,7 @@
 body {
   background: var(--background);
   color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: var(--font-sans);
 }
 
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -7,6 +7,13 @@ import GoogleAnalyticsLoader from "../components/GoogleAnalyticsLoader";
 import Footer from "../components/Footer";
 import { SiteConfigProvider } from "../contexts/SiteConfigContext";
 import { CookieConsentProvider } from "../contexts/CookieConsentContext";
+import { Inter } from "next/font/google";
+
+const inter = Inter({
+  subsets: ["latin"],
+  display: "swap",
+  variable: "--font-inter",
+});
 
 
 export const metadata: Metadata = {
@@ -20,8 +27,8 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
-      <body className="antialiased bg-white text-gray-900">
+    <html lang="en" className={inter.variable}>
+      <body className={`${inter.className} antialiased bg-white text-gray-900`}>
         <SiteConfigProvider>
           <CookieConsentProvider>
             <div className="flex flex-col min-h-screen">


### PR DESCRIPTION
## Summary
- load Inter via next/font in `layout.tsx`
- use new CSS variable to make Inter the default sans font
- document the Inter font setup in README

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font `Inter` due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_b_6853c852756083318040b3af2522631c