### PR TITLE
Refine theme styling

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -118,8 +118,8 @@ const HomePage: React.FC = () => {
       )}
 
       <header className="mb-8 text-center">
-        <h1 className="text-4xl font-bold text-gray-900">Welcome to the Blog</h1>
-        <p className="text-lg text-gray-600 mt-2">Discover insights and stories on web development, technology, and more.</p>
+        <h1 className="text-4xl font-bold text-primary-800">Welcome to the Blog</h1>
+        <p className="text-lg text-primary-600 mt-2">Discover insights and stories on web development, technology, and more.</p>
       </header>
       
       {currentPosts.length > 0 ? (

--- a/app/tags/page.tsx
+++ b/app/tags/page.tsx
@@ -85,7 +85,7 @@ const TagsPage: React.FC = () => {
             <Link
               key={tag}
               href={`/tags/${slugify(tag)}`}
-              className="bg-primary-700 text-white text-lg font-semibold px-6 py-3 rounded hover:bg-primary-800 transition-colors"
+              className="bg-primary-100 text-primary-800 text-lg font-semibold px-6 py-3 rounded hover:bg-primary-200 transition-colors"
               aria-label={`View posts tagged with ${tag}`}
             >
               {tag}
@@ -94,7 +94,7 @@ const TagsPage: React.FC = () => {
         </div>
       ) : (
         <div className="text-center py-12">
-          <h2 className="text-2xl font-semibold text-gray-700">No tags found.</h2>
+          <h2 className="text-2xl font-semibold text-primary-800">No tags found.</h2>
           <p className="text-gray-500 mt-2">It looks like there are no tags associated with any posts yet, or the post manifest file is not configured.</p>
         </div>
       )}


### PR DESCRIPTION
## Summary
- apply primary theme color to homepage heading
- style tag list chips to match tag chips in posts

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_6853f6570e24833198fa86eb5666b0be