### PR TITLE
Fix card click coverage

### DIFF
--- a/components/PostCard.tsx
+++ b/components/PostCard.tsx
@@ -22,7 +22,7 @@ const PostCard: React.FC<PostCardProps> = ({ post }) => {
     <article className="relative bg-white border rounded-lg overflow-hidden hover:shadow-md transition-shadow flex flex-col cursor-pointer">
       <Link
         href={`/post/${post.slug}`}
-        className="absolute inset-0 z-10"
+        className="absolute inset-0 z-20"
         aria-label={`Read more about ${post.title}`}
       >
         <span className="sr-only">{`Read more about ${post.title}`}</span>
@@ -39,7 +39,7 @@ const PostCard: React.FC<PostCardProps> = ({ post }) => {
           />
         </div>
       )}
-      <div className="p-6 flex flex-col flex-grow relative z-20">
+      <div className="p-6 flex flex-col flex-grow relative z-10">
         <h2 className="text-2xl font-bold text-primary-800 mb-2">{post.title}</h2>
         <div className="text-sm text-gray-500 mb-3">
           <span>By {post.author}</span> | <span>{new Date(post.date).toLocaleDateString()}</span>
@@ -50,7 +50,7 @@ const PostCard: React.FC<PostCardProps> = ({ post }) => {
             <Link
               key={tag}
               href={`/tags/${slugify(tag)}`}
-              className="inline-block bg-primary-100 text-primary-800 text-xs font-semibold mr-2 mb-2 px-2.5 py-0.5 rounded-full hover:bg-primary-200 transition-colors duration-200"
+              className="inline-block bg-primary-100 text-primary-800 text-xs font-semibold mr-2 mb-2 px-2.5 py-0.5 rounded-full hover:bg-primary-200 transition-colors duration-200 relative z-30"
               aria-label={`View posts tagged with ${tag}`}
             >
               {tag}


### PR DESCRIPTION
## Summary
- ensure the PostCard overlay link sits above card text
- keep tag links clickable when overlay is present

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_6853fdedb1d883318f2296c3f0ba75b0