### PR TITLE
Enable dark mode theme with toggle

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -6,6 +6,11 @@
   --foreground: #171717;
 }
 
+html.dark {
+  --background: #0a0a0a;
+  --foreground: #ededed;
+}
+
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
@@ -1140,20 +1145,7 @@ video {
   color: rgb(30 64 175 / var(--tw-text-opacity, 1))
 }
 
-.hover\:text-\[\#0A66C2\]:hover {
-  --tw-text-opacity: 1;
-  color: rgb(10 102 194 / var(--tw-text-opacity, 1))
-}
 
-.hover\:text-\[\#1877F2\]:hover {
-  --tw-text-opacity: 1;
-  color: rgb(24 119 242 / var(--tw-text-opacity, 1))
-}
-
-.hover\:text-\[\#1DA1F2\]:hover {
-  --tw-text-opacity: 1;
-  color: rgb(29 161 242 / var(--tw-text-opacity, 1))
-}
 
 .hover\:text-primary-600:hover {
   --tw-text-opacity: 1;
@@ -1201,19 +1193,8 @@ video {
   --tw-ring-color: rgb(134 239 172 / var(--tw-ring-opacity, 1))
 }
 
-.focus\:ring-\[\#0A66C2\]:focus {
-  --tw-ring-opacity: 1;
-  --tw-ring-color: rgb(10 102 194 / var(--tw-ring-opacity, 1))
-}
 
-.focus\:ring-\[\#1877F2\]:focus {
-  --tw-ring-opacity: 1;
-  --tw-ring-color: rgb(24 119 242 / var(--tw-ring-opacity, 1))
 }
-
-.focus\:ring-\[\#1DA1F2\]:focus {
-  --tw-ring-opacity: 1;
-  --tw-ring-color: rgb(29 161 242 / var(--tw-ring-opacity, 1))
 }
 
 .focus\:ring-primary-500:focus {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -7,6 +7,7 @@ import GoogleAnalyticsLoader from "../components/GoogleAnalyticsLoader";
 import Footer from "../components/Footer";
 import { SiteConfigProvider } from "../contexts/SiteConfigContext";
 import { CookieConsentProvider } from "../contexts/CookieConsentContext";
+import { ThemeProvider } from "../contexts/ThemeContext";
 import { Inter } from "next/font/google";
 
 const inter = Inter({
@@ -28,21 +29,23 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en" className={inter.variable}>
-      <body className={`${inter.className} antialiased bg-white text-gray-900`}>
-        <SiteConfigProvider>
-          <CookieConsentProvider>
-            <div className="flex flex-col min-h-screen">
-              <Navbar />
-              <main className="flex-grow bg-gray-50 py-8">
-                <AnalyticsRouteChangeTracker />
-                <GoogleAnalyticsLoader />
-                {children}
-              </main>
-              <CookieConsentBanner />
-              <Footer />
-            </div>
-          </CookieConsentProvider>
-        </SiteConfigProvider>
+      <body className={`${inter.className} antialiased bg-white text-gray-900 dark:bg-black dark:text-gray-100`}>
+        <ThemeProvider>
+          <SiteConfigProvider>
+            <CookieConsentProvider>
+              <div className="flex flex-col min-h-screen">
+                <Navbar />
+                <main className="flex-grow bg-gray-50 dark:bg-gray-900 py-8">
+                  <AnalyticsRouteChangeTracker />
+                  <GoogleAnalyticsLoader />
+                  {children}
+                </main>
+                <CookieConsentBanner />
+                <Footer />
+              </div>
+            </CookieConsentProvider>
+          </SiteConfigProvider>
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -89,7 +89,7 @@ const HomePage: React.FC = () => {
     return (
       <div className="flex justify-center items-center min-h-[calc(100vh-200px)]">
         <div className="animate-spin rounded-full h-16 w-16 border-t-4 border-b-4 border-primary-700"></div>
-        <p className="ml-4 text-lg text-gray-700">Loading posts...</p>
+        <p className="ml-4 text-lg text-gray-700 dark:text-gray-300">Loading posts...</p>
       </div>
     );
   }
@@ -98,7 +98,7 @@ const HomePage: React.FC = () => {
     return (
       <div className="container mx-auto px-4 py-8 text-center">
         <h1 className="text-3xl font-bold text-red-600 mb-4">Error Loading Posts</h1>
-        <p className="text-lg text-gray-700 whitespace-pre-line">{postsError}</p>
+        <p className="text-lg text-gray-700 dark:text-gray-300 whitespace-pre-line">{postsError}</p>
       </div>
     );
   }
@@ -118,8 +118,8 @@ const HomePage: React.FC = () => {
       )}
 
       <header className="mb-8 text-center">
-        <h1 className="text-4xl font-bold text-primary-800">Welcome to the Blog</h1>
-        <p className="text-lg text-primary-600 mt-2">Discover insights and stories on web development, technology, and more.</p>
+        <h1 className="text-4xl font-bold text-primary-800 dark:text-primary-100">Welcome to the Blog</h1>
+        <p className="text-lg text-primary-600 dark:text-primary-300 mt-2">Discover insights and stories on web development, technology, and more.</p>
       </header>
       
       {currentPosts.length > 0 ? (
@@ -134,7 +134,7 @@ const HomePage: React.FC = () => {
               <button
                 onClick={() => paginate(currentPage - 1)}
                 disabled={currentPage === 1}
-                className="px-4 py-2 bg-primary-700 text-white rounded hover:bg-primary-800 disabled:bg-gray-300 disabled:cursor-not-allowed transition-colors"
+                className="px-4 py-2 bg-primary-700 hover:bg-primary-800 text-white rounded disabled:bg-gray-300 disabled:cursor-not-allowed transition-colors"
                 aria-label="Previous page"
               >
                 &larr; Previous
@@ -146,7 +146,7 @@ const HomePage: React.FC = () => {
                   className={`px-4 py-2 rounded transition-colors ${
                     currentPage === number
                       ? 'bg-primary-800 text-white font-bold ring-2 ring-primary-500'
-                      : 'bg-primary-100 text-primary-800 hover:bg-primary-200'
+                      : 'bg-primary-100 dark:bg-primary-700 text-primary-800 dark:text-primary-100 hover:bg-primary-200 dark:hover:bg-primary-600'
                   }`}
                   aria-current={currentPage === number ? "page" : undefined}
                   aria-label={`Go to page ${number}`}
@@ -157,7 +157,7 @@ const HomePage: React.FC = () => {
               <button
                 onClick={() => paginate(currentPage + 1)}
                 disabled={currentPage === totalPages}
-                className="px-4 py-2 bg-primary-700 text-white rounded hover:bg-primary-800 disabled:bg-gray-300 disabled:cursor-not-allowed transition-colors"
+                className="px-4 py-2 bg-primary-700 hover:bg-primary-800 text-white rounded disabled:bg-gray-300 disabled:cursor-not-allowed transition-colors"
                 aria-label="Next page"
               >
                 Next &rarr;
@@ -167,8 +167,8 @@ const HomePage: React.FC = () => {
         </>
       ) : (
         <div className="text-center py-12">
-          <h2 className="text-2xl font-semibold text-gray-700">No posts yet!</h2>
-          <p className="text-gray-500 mt-2">Check back soon for new content, or ensure the post manifest file is configured if posts exist.</p>
+          <h2 className="text-2xl font-semibold text-gray-700 dark:text-gray-300">No posts yet!</h2>
+          <p className="text-gray-500 dark:text-gray-400 mt-2">Check back soon for new content, or ensure the post manifest file is configured if posts exist.</p>
         </div>
       )}
     </div>

--- a/app/page/[slug]/page.tsx
+++ b/app/page/[slug]/page.tsx
@@ -39,21 +39,21 @@ const GenericPage = async ({ params }: PageProps) => {
 
     return (
       <div className="container mx-auto px-4 py-8 max-w-4xl">
-        <article className="bg-white border rounded-lg p-6 md:p-10">
-          <header className="mb-8 border-b pb-6 border-gray-200">
-            <h1 className="text-4xl md:text-5xl font-extrabold text-primary-800">{pageData.title}</h1>
+        <article className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-6 md:p-10">
+          <header className="mb-8 border-b pb-6 border-gray-200 dark:border-gray-700">
+            <h1 className="text-4xl md:text-5xl font-extrabold text-primary-800 dark:text-primary-100">{pageData.title}</h1>
           </header>
 
           {pageData.markdownContent ? (
             <MarkdownRenderer content={pageData.markdownContent} />
           ) : (
-            <p className="text-gray-500">Content is not available for this page.</p>
+            <p className="text-gray-500 dark:text-gray-400">Content is not available for this page.</p>
           )}
 
-          <footer className="mt-12 pt-6 border-t border-gray-200">
+          <footer className="mt-12 pt-6 border-t border-gray-200 dark:border-gray-700">
             <Link
               href="/"
-              className="text-primary-700 hover:text-primary-800 hover:underline font-semibold transition-colors"
+              className="text-primary-700 dark:text-primary-300 hover:text-primary-800 dark:hover:text-primary-100 hover:underline font-semibold transition-colors"
             >
               &larr; Back to Home
             </Link>
@@ -67,7 +67,7 @@ const GenericPage = async ({ params }: PageProps) => {
     return (
       <div className="container mx-auto px-4 py-8 text-center">
         <h1 className="text-4xl font-bold text-red-600 mb-4">Error</h1>
-        <p className="text-lg text-gray-700 mb-6">{`Could not load page content. ${message}`}</p>
+        <p className="text-lg text-gray-700 dark:text-gray-300 mb-6">{`Could not load page content. ${message}`}</p>
         <Link
           href="/"
           className="bg-primary-700 text-white font-semibold px-6 py-3 rounded hover:bg-primary-800 transition-colors duration-300"

--- a/app/post/[slug]/page.tsx
+++ b/app/post/[slug]/page.tsx
@@ -112,10 +112,10 @@ const PostPage = async ({ params }: PageProps) => {
 
   return (
     <div className="container mx-auto px-4 py-8 max-w-4xl">
-      <article className="bg-white border rounded-lg p-6 md:p-10">
-        <header className="mb-8 border-b pb-6 border-gray-200">
+      <article className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-6 md:p-10">
+        <header className="mb-8 border-b pb-6 border-gray-200 dark:border-gray-700">
           <h1 className="text-4xl md:text-5xl font-extrabold text-primary-800 mb-3">{post.title}</h1>
-          <div className="text-md text-gray-500">
+          <div className="text-md text-gray-500 dark:text-gray-400">
             <span>By {post.author}</span> | <span>Published on {new Date(post.date).toLocaleDateString()}</span>
           </div>
           {post.tags && post.tags.length > 0 && (
@@ -124,7 +124,7 @@ const PostPage = async ({ params }: PageProps) => {
                 <Link
                   key={tag}
                   href={`/tags/${slugify(tag)}`}
-                  className="inline-block bg-primary-100 text-primary-800 text-xs font-semibold mr-2 mb-2 px-2.5 py-0.5 rounded-full hover:bg-primary-200 transition-colors duration-200"
+                  className="inline-block bg-primary-100 dark:bg-primary-700 text-primary-800 dark:text-primary-100 text-xs font-semibold mr-2 mb-2 px-2.5 py-0.5 rounded-full hover:bg-primary-200 dark:hover:bg-primary-600 transition-colors duration-200"
                   aria-label={`View posts tagged with ${tag}`}
                 >
                   {tag}
@@ -153,17 +153,17 @@ const PostPage = async ({ params }: PageProps) => {
         {post.markdownContent ? (
           <MarkdownRenderer content={post.markdownContent} />
         ) : (
-          <p className="text-gray-500">Content is not available for this post.</p>
+          <p className="text-gray-500 dark:text-gray-400">Content is not available for this post.</p>
         )}
 
-        <div className="mt-10 pt-8 border-t border-gray-200">
-          <h3 className="text-xl font-semibold text-gray-800 mb-4">Share this post</h3>
+        <div className="mt-10 pt-8 border-t border-gray-200 dark:border-gray-700">
+          <h3 className="text-xl font-semibold text-gray-800 dark:text-gray-200 mb-4">Share this post</h3>
           <div className="flex items-center space-x-3 sm:space-x-4">
             <a
               href={shareLinks.twitter}
               aria-label="Share on Twitter"
               title="Share on Twitter"
-              className="text-gray-500 hover:text-[#1DA1F2] p-2.5 rounded-full hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[#1DA1F2] transition-colors duration-200"
+              className="text-gray-500 dark:text-gray-400 hover:text-primary-600 dark:hover:text-primary-300 p-2.5 rounded-full hover:bg-gray-100 dark:hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500 transition-colors duration-200"
               target="_blank" rel="noopener noreferrer"
             >
               <TwitterIcon />
@@ -172,7 +172,7 @@ const PostPage = async ({ params }: PageProps) => {
               href={shareLinks.facebook}
               aria-label="Share on Facebook"
               title="Share on Facebook"
-              className="text-gray-500 hover:text-[#1877F2] p-2.5 rounded-full hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[#1877F2] transition-colors duration-200"
+              className="text-gray-500 dark:text-gray-400 hover:text-primary-600 dark:hover:text-primary-300 p-2.5 rounded-full hover:bg-gray-100 dark:hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500 transition-colors duration-200"
               target="_blank" rel="noopener noreferrer"
             >
               <FacebookIcon />
@@ -181,7 +181,7 @@ const PostPage = async ({ params }: PageProps) => {
               href={shareLinks.linkedin}
               aria-label="Share on LinkedIn"
               title="Share on LinkedIn"
-              className="text-gray-500 hover:text-[#0A66C2] p-2.5 rounded-full hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[#0A66C2] transition-colors duration-200"
+              className="text-gray-500 dark:text-gray-400 hover:text-primary-600 dark:hover:text-primary-300 p-2.5 rounded-full hover:bg-gray-100 dark:hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500 transition-colors duration-200"
               target="_blank" rel="noopener noreferrer"
             >
               <LinkedInIcon />
@@ -190,7 +190,7 @@ const PostPage = async ({ params }: PageProps) => {
               href={shareLinks.email}
               aria-label="Share via Email"
               title="Share via Email"
-              className="text-gray-500 hover:text-primary-700 p-2.5 rounded-full hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500 transition-colors duration-200"
+              className="text-gray-500 dark:text-gray-400 hover:text-primary-700 dark:hover:text-primary-300 p-2.5 rounded-full hover:bg-gray-100 dark:hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500 transition-colors duration-200"
               target="_blank" rel="noopener noreferrer"
             >
               <EmailIcon />

--- a/app/tags/[tagName]/page.tsx
+++ b/app/tags/[tagName]/page.tsx
@@ -83,12 +83,12 @@ const PostsByTagPage = async ({ params }: PageProps) => {
   return (
     <div className="container mx-auto px-4 py-8">
       <header className="mb-10">
-        <h1 className="text-4xl font-bold text-primary-800 mb-2">
-          Posts tagged with: <span className="text-primary-700">{displayTag || 'Unknown Tag'}</span>
+        <h1 className="text-4xl font-bold text-primary-800 dark:text-primary-100 mb-2">
+          Posts tagged with: <span className="text-primary-700 dark:text-primary-300">{displayTag || 'Unknown Tag'}</span>
         </h1>
         <Link
           href="/tags"
-          className="text-primary-700 hover:text-primary-800 hover:underline font-semibold transition-colors"
+          className="text-primary-700 dark:text-primary-300 hover:text-primary-800 dark:hover:text-primary-100 hover:underline font-semibold transition-colors"
         >
           &larr; View all tags
         </Link>
@@ -102,11 +102,11 @@ const PostsByTagPage = async ({ params }: PageProps) => {
         </div>
       ) : (
         <div className="text-center py-12">
-          <h2 className="text-2xl font-semibold text-gray-700">No posts found for this tag.</h2>
-          <p className="text-gray-500 mt-2">Try browsing other tags or viewing all posts. Ensure the post manifest is configured if you expect posts here.</p>
+          <h2 className="text-2xl font-semibold text-gray-700 dark:text-gray-300">No posts found for this tag.</h2>
+          <p className="text-gray-500 dark:text-gray-400 mt-2">Try browsing other tags or viewing all posts. Ensure the post manifest is configured if you expect posts here.</p>
           <Link
             href="/"
-            className="mt-6 inline-block bg-primary-700 text-white font-semibold px-6 py-3 rounded hover:bg-primary-800 transition-colors"
+            className="mt-6 inline-block bg-primary-700 hover:bg-primary-800 text-white font-semibold px-6 py-3 rounded transition-colors"
           >
             View All Posts
           </Link>

--- a/app/tags/page.tsx
+++ b/app/tags/page.tsx
@@ -56,9 +56,9 @@ const TagsPage: React.FC = () => {
 
   if (isLoading) {
     return (
-      <div className="flex justify-center items-center min-h-[calc(100vh-200px)]">
+        <div className="flex justify-center items-center min-h-[calc(100vh-200px)]">
         <div className="animate-spin rounded-full h-16 w-16 border-t-4 border-b-4 border-primary-700"></div>
-        <p className="ml-4 text-lg text-gray-700">Loading tags...</p>
+        <p className="ml-4 text-lg text-gray-700 dark:text-gray-300">Loading tags...</p>
       </div>
     );
   }
@@ -67,7 +67,7 @@ const TagsPage: React.FC = () => {
     return (
       <div className="container mx-auto px-4 py-8 text-center">
         <h1 className="text-3xl font-bold text-red-600 mb-4">Error Loading Tags</h1>
-        <p className="text-lg text-gray-700 whitespace-pre-line">{error}</p>
+        <p className="text-lg text-gray-700 dark:text-gray-300 whitespace-pre-line">{error}</p>
       </div>
     );
   }
@@ -75,8 +75,8 @@ const TagsPage: React.FC = () => {
   return (
     <div className="container mx-auto px-4 py-8">
       <header className="mb-10 text-center">
-        <h1 className="text-5xl font-extrabold text-primary-800">All Tags</h1>
-        <p className="text-xl text-gray-600 mt-2">Browse posts by topic.</p>
+        <h1 className="text-5xl font-extrabold text-primary-800 dark:text-primary-100">All Tags</h1>
+        <p className="text-xl text-gray-600 dark:text-gray-300 mt-2">Browse posts by topic.</p>
       </header>
 
       {tags.length > 0 ? (
@@ -85,7 +85,7 @@ const TagsPage: React.FC = () => {
             <Link
               key={tag}
               href={`/tags/${slugify(tag)}`}
-              className="bg-primary-100 text-primary-800 text-lg font-semibold px-6 py-3 rounded hover:bg-primary-200 transition-colors"
+              className="bg-primary-100 dark:bg-primary-700 text-primary-800 dark:text-primary-100 text-lg font-semibold px-6 py-3 rounded hover:bg-primary-200 dark:hover:bg-primary-600 transition-colors"
               aria-label={`View posts tagged with ${tag}`}
             >
               {tag}
@@ -94,8 +94,8 @@ const TagsPage: React.FC = () => {
         </div>
       ) : (
         <div className="text-center py-12">
-          <h2 className="text-2xl font-semibold text-primary-800">No tags found.</h2>
-          <p className="text-gray-500 mt-2">It looks like there are no tags associated with any posts yet, or the post manifest file is not configured.</p>
+          <h2 className="text-2xl font-semibold text-primary-800 dark:text-primary-100">No tags found.</h2>
+          <p className="text-gray-500 dark:text-gray-400 mt-2">It looks like there are no tags associated with any posts yet, or the post manifest file is not configured.</p>
         </div>
       )}
     </div>

--- a/components/CookieConsentBanner.tsx
+++ b/components/CookieConsentBanner.tsx
@@ -13,7 +13,7 @@ const CookieConsentBanner: React.FC = () => {
 
   return (
     <div
-      className="fixed bottom-0 left-0 right-0 bg-white text-gray-800 p-4 shadow-md border-t border-gray-200 z-[100]"
+      className="fixed bottom-0 left-0 right-0 bg-white dark:bg-gray-900 text-gray-800 dark:text-gray-100 p-4 shadow-md border-t border-gray-200 dark:border-gray-700 z-[100]"
       role="dialog"
       aria-live="polite"
       aria-label="Consenso cookie"
@@ -22,14 +22,14 @@ const CookieConsentBanner: React.FC = () => {
         <p className="text-sm mb-3 sm:mb-0 sm:mr-4">
           Usiamo cookie tecnici indispensabili al funzionamento del sito e, solo se acconsenti, cookie di analytics per statistiche anonime.
           Per maggiori dettagli consulta la nostra{' '}
-          <Link href="/page/cookie-policy" className="underline hover:text-primary-600">
+          <Link href="/page/cookie-policy" className="underline hover:text-primary-600 dark:hover:text-primary-400">
             Cookie Policy
           </Link>.
         </p>
         <div className="flex space-x-3">
           <button
             onClick={declineConsent}
-            className="px-4 py-2 text-sm font-medium rounded-md bg-gray-200 hover:bg-gray-300 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500"
+            className="px-4 py-2 text-sm font-medium rounded-md bg-gray-200 dark:bg-gray-700 hover:bg-gray-300 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500"
             aria-label="Rifiuta cookie"
           >
             Rifiuta

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -7,21 +7,21 @@ const Footer: React.FC = () => {
   const { openBanner } = useCookieConsent();
 
   return (
-    <footer className="bg-gray-100 text-gray-600 text-center p-6 border-t">
+    <footer className="bg-gray-100 dark:bg-gray-900 text-gray-600 dark:text-gray-300 text-center p-6 border-t border-gray-200 dark:border-gray-700">
       <p>&copy; {new Date().getFullYear()} React Markdown Blog. All rights reserved.</p>
       <p className="text-sm mt-1">Powered by React, Tailwind CSS, and your Markdown!</p>
       <nav className="text-sm mt-1 space-x-1">
-        <Link href="/page/privacy-policy" className="underline hover:text-primary-600">
+        <Link href="/page/privacy-policy" className="underline hover:text-primary-600 dark:hover:text-primary-400">
           Privacy Policy
         </Link>
         <span>|</span>
-        <Link href="/page/cookie-policy" className="underline hover:text-primary-600 ml-1">
+        <Link href="/page/cookie-policy" className="underline hover:text-primary-600 dark:hover:text-primary-400 ml-1">
           Cookie Policy
         </Link>
       </nav>
       <button
         onClick={openBanner}
-        className="mt-2 underline text-sm hover:text-primary-600 focus:outline-none"
+        className="mt-2 underline text-sm hover:text-primary-600 dark:hover:text-primary-400 focus:outline-none"
         aria-label="Gestisci preferenze cookie"
       >
         Gestisci preferenze cookie

--- a/components/MarkdownRenderer.tsx
+++ b/components/MarkdownRenderer.tsx
@@ -9,11 +9,11 @@ interface MarkdownRendererProps {
 
 const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({ content }) => {
   const customComponents: Components = {
-    h1: ({ ...props }) => <h1 className="text-4xl font-bold my-6 border-b pb-2 border-gray-300" {...props} />,
-    h2: ({ ...props }) => <h2 className="text-3xl font-semibold my-5 border-b pb-2 border-gray-200" {...props} />,
+    h1: ({ ...props }) => <h1 className="text-4xl font-bold my-6 border-b pb-2 border-gray-300 dark:border-gray-700" {...props} />,
+    h2: ({ ...props }) => <h2 className="text-3xl font-semibold my-5 border-b pb-2 border-gray-200 dark:border-gray-600" {...props} />,
     h3: ({ ...props }) => <h3 className="text-2xl font-semibold my-4" {...props} />,
     p: ({ ...props }) => <p className="my-4 leading-relaxed" {...props} />,
-    a: ({ ...props }) => <a className="text-primary-700 hover:text-primary-800 underline" {...props} />, 
+    a: ({ ...props }) => <a className="text-primary-700 dark:text-primary-300 hover:text-primary-800 dark:hover:text-primary-100 underline" {...props} />,
     ul: ({ ...props }) => <ul className="list-disc pl-8 my-4 space-y-1" {...props} />,
     ol: ({ ...props }) => <ol className="list-decimal pl-8 my-4 space-y-1" {...props} />,
     li: ({ ...props }) => <li className="my-1" {...props} />,
@@ -30,16 +30,16 @@ const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({ content }) => {
       }
       // For inline code, ensure className is handled gracefully
       return (
-        <code className={`bg-gray-200 text-red-600 px-1 py-0.5 rounded text-sm ${className || ''}`} {...props}>
+        <code className={`bg-gray-200 dark:bg-gray-800 text-red-600 px-1 py-0.5 rounded text-sm ${className || ''}`} {...props}>
           {children}
         </code>
       );
     },
-    blockquote: ({ ...props }) => <blockquote className="border-l-4 border-gray-300 pl-4 italic my-4 text-gray-600" {...props} />,
+    blockquote: ({ ...props }) => <blockquote className="border-l-4 border-gray-300 dark:border-gray-600 pl-4 italic my-4 text-gray-600 dark:text-gray-400" {...props} />,
   };
 
   return (
-    <div className="prose prose-lg max-w-none text-gray-800">
+    <div className="prose prose-lg max-w-none text-gray-800 dark:text-gray-200">
       <ReactMarkdown
         remarkPlugins={[remarkGfm]}
         components={customComponents}

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -4,11 +4,13 @@ import React, { useState, useEffect } from 'react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { useSiteConfig } from '../contexts/SiteConfigContext';
+import { useTheme } from '../contexts/ThemeContext';
 
 const Navbar: React.FC = () => {
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
   const pathname = usePathname();
   const { config, isLoading: isConfigLoading, error: configError } = useSiteConfig();
+  const { theme, toggleTheme } = useTheme();
 
   // Close mobile menu on route change
   useEffect(() => {
@@ -21,13 +23,13 @@ const Navbar: React.FC = () => {
 
   const getNavLinkClass = (path: string) =>
     pathname === path
-      ? "text-primary-800 border-b-2 border-primary-800 pb-1"
-      : "hover:text-primary-600 transition-colors pb-1 border-b-2 border-transparent hover:border-primary-400";
+      ? "text-primary-800 dark:text-primary-100 border-b-2 border-primary-800 dark:border-primary-100 pb-1"
+      : "hover:text-primary-600 dark:hover:text-primary-300 transition-colors pb-1 border-b-2 border-transparent hover:border-primary-400 dark:hover:border-primary-300";
 
   const getMobileNavLinkClass = (path: string) =>
     pathname === path
-      ? "block py-2 px-3 text-primary-800 bg-primary-100 rounded"
-      : "block py-2 px-3 hover:bg-primary-100 hover:text-primary-800 rounded transition-colors";
+      ? "block py-2 px-3 text-primary-800 dark:text-primary-100 bg-primary-100 dark:bg-primary-700 rounded"
+      : "block py-2 px-3 hover:bg-primary-100 dark:hover:bg-primary-700 hover:text-primary-800 dark:hover:text-primary-100 rounded transition-colors";
 
   const navLinks = [
     { to: "/", text: "Home" },
@@ -38,9 +40,9 @@ const Navbar: React.FC = () => {
   const displayTitle = isConfigLoading ? "Loading..." : (configError ? "Blog" : config.blogTitle);
 
   return (
-    <nav className="bg-white border-b border-gray-200 sticky top-0 z-50">
+    <nav className="bg-white dark:bg-gray-900 border-b border-gray-200 dark:border-gray-700 sticky top-0 z-50">
       <div className="container mx-auto px-6 py-4 flex justify-between items-center">
-        <Link href="/" className="text-2xl font-bold text-primary-800 hover:text-primary-600 transition-colors" aria-label="Go to homepage">
+        <Link href="/" className="text-2xl font-bold text-primary-800 dark:text-primary-100 hover:text-primary-600 dark:hover:text-primary-300 transition-colors" aria-label="Go to homepage">
           {displayTitle}
         </Link>
 
@@ -51,6 +53,22 @@ const Navbar: React.FC = () => {
               {link.text}
             </Link>
           ))}
+          <button
+            onClick={toggleTheme}
+            aria-label="Toggle dark mode"
+            className="p-2 rounded-md text-primary-800 dark:text-primary-200 hover:bg-gray-100 dark:hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-primary-500"
+          >
+            {theme === 'dark' ? (
+              <svg className="h-6 w-6" xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M12 18a6 6 0 100-12 6 6 0 000 12z" />
+                <path d="M12 2v2m0 16v2m8-10h2M2 12h2m13.657-6.657l1.414-1.414M4.929 19.071l1.414-1.414m0-12.728L4.93 4.93m14.142 14.142l-1.414-1.414" />
+              </svg>
+            ) : (
+              <svg className="h-6 w-6" xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
+                <path d="M17.293 13.293A8 8 0 016.707 2.707a8 8 0 1010.586 10.586z" />
+              </svg>
+            )}
+          </button>
         </div>
 
         {/* Mobile Menu Button */}
@@ -60,7 +78,7 @@ const Navbar: React.FC = () => {
             aria-label="Toggle navigation menu"
             aria-expanded={isMobileMenuOpen}
             aria-controls="mobile-menu"
-            className="p-2 rounded-md text-primary-800 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-primary-500"
+            className="p-2 rounded-md text-primary-800 dark:text-primary-200 hover:bg-gray-100 dark:hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-primary-500"
           >
             {isMobileMenuOpen ? (
               // X icon
@@ -79,7 +97,7 @@ const Navbar: React.FC = () => {
 
       {/* Mobile Menu */}
       {isMobileMenuOpen && (
-        <div id="mobile-menu" className="md:hidden bg-white border-t border-gray-200">
+        <div id="mobile-menu" className="md:hidden bg-white dark:bg-gray-800 border-t border-gray-200 dark:border-gray-700">
           <div className="px-2 pt-2 pb-3 space-y-1 sm:px-3">
             {navLinks.map(link => (
               <Link
@@ -91,6 +109,16 @@ const Navbar: React.FC = () => {
                 {link.text}
               </Link>
             ))}
+            <button
+              onClick={() => {
+                toggleTheme();
+                setIsMobileMenuOpen(false);
+              }}
+              aria-label="Toggle dark mode"
+              className="block py-2 px-3 rounded text-left w-full text-primary-800 dark:text-primary-200 hover:bg-primary-100 dark:hover:bg-primary-700 transition-colors"
+            >
+              {theme === 'dark' ? 'Light mode' : 'Dark mode'}
+            </button>
           </div>
         </div>
       )}

--- a/components/PostCard.tsx
+++ b/components/PostCard.tsx
@@ -19,7 +19,7 @@ const PostCard: React.FC<PostCardProps> = ({ post }) => {
       : post.imageUrl;
 
   return (
-    <article className="relative bg-white border rounded-lg overflow-hidden hover:shadow-md transition-shadow flex flex-col cursor-pointer">
+    <article className="relative bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg overflow-hidden hover:shadow-md transition-shadow flex flex-col cursor-pointer">
       <Link
         href={`/post/${post.slug}`}
         className="absolute inset-0 z-20"
@@ -40,17 +40,17 @@ const PostCard: React.FC<PostCardProps> = ({ post }) => {
         </div>
       )}
       <div className="p-6 flex flex-col flex-grow relative z-10">
-        <h2 className="text-2xl font-bold text-primary-800 mb-2">{post.title}</h2>
-        <div className="text-sm text-gray-500 mb-3">
+        <h2 className="text-2xl font-bold text-primary-800 dark:text-primary-100 mb-2">{post.title}</h2>
+        <div className="text-sm text-gray-500 dark:text-gray-400 mb-3">
           <span>By {post.author}</span> | <span>{new Date(post.date).toLocaleDateString()}</span>
         </div>
-        <p className="text-gray-700 mb-4 leading-relaxed flex-grow">{post.excerpt}</p>
+        <p className="text-gray-700 dark:text-gray-300 mb-4 leading-relaxed flex-grow">{post.excerpt}</p>
         <div className="mb-4">
           {post.tags.map(tag => (
             <Link
               key={tag}
               href={`/tags/${slugify(tag)}`}
-              className="inline-block bg-primary-100 text-primary-800 text-xs font-semibold mr-2 mb-2 px-2.5 py-0.5 rounded-full hover:bg-primary-200 transition-colors duration-200 relative z-30"
+              className="inline-block bg-primary-100 dark:bg-primary-700 text-primary-800 dark:text-primary-100 text-xs font-semibold mr-2 mb-2 px-2.5 py-0.5 rounded-full hover:bg-primary-200 dark:hover:bg-primary-600 transition-colors duration-200 relative z-30"
               aria-label={`View posts tagged with ${tag}`}
             >
               {tag}

--- a/contexts/ThemeContext.tsx
+++ b/contexts/ThemeContext.tsx
@@ -1,0 +1,46 @@
+"use client";
+import React, { createContext, useContext, useEffect, useState } from "react";
+
+type Theme = "light" | "dark";
+
+interface ThemeContextType {
+  theme: Theme;
+  toggleTheme: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
+
+export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [theme, setTheme] = useState<Theme>("light");
+
+  useEffect(() => {
+    const stored = (typeof localStorage !== "undefined" ? localStorage.getItem("theme") : null) as Theme | null;
+    const systemPref = window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+    const initial = stored || systemPref;
+    setTheme(initial);
+    document.documentElement.classList.toggle("dark", initial === "dark");
+  }, []);
+
+  const toggleTheme = () => {
+    const next = theme === "dark" ? "light" : "dark";
+    setTheme(next);
+    document.documentElement.classList.toggle("dark", next === "dark");
+    if (typeof localStorage !== "undefined") {
+      localStorage.setItem("theme", next);
+    }
+  };
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+};
+
+export const useTheme = () => {
+  const ctx = useContext(ThemeContext);
+  if (!ctx) {
+    throw new Error("useTheme must be used within ThemeProvider");
+  }
+  return ctx;
+};

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -3,6 +3,7 @@ module.exports = {
     './app/**/*.{js,ts,jsx,tsx}',
     './components/**/*.{js,ts,jsx,tsx}',
   ],
+  darkMode: 'class',
   theme: {
     extend: {
       colors: {


### PR DESCRIPTION
## Summary
- add ThemeContext with system preference detection
- enable class-based dark mode in Tailwind
- create theme toggle in Navbar
- style components and pages for dark mode
- remove unused blue highlight rules from CSS

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_685404165a188331b58dc26a3df47086