### PR TITLE
Remove stray braces causing CSS parse error

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1194,8 +1194,6 @@ video {
 }
 
 
-}
-}
 
 .focus\:ring-primary-500:focus {
   --tw-ring-opacity: 1;


### PR DESCRIPTION
## Summary
- fix extra closing braces in `globals.css`

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font `Inter`)*

------
https://chatgpt.com/codex/tasks/task_b_68540e5272348331a6cec9fb0db4c9c8