### PR TITLE
Add centralized theming

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,6 +5,7 @@ import CookieConsentBanner from "../components/CookieConsentBanner";
 import AnalyticsRouteChangeTracker from "../components/AnalyticsRouteChangeTracker";
 import GoogleAnalyticsLoader from "../components/GoogleAnalyticsLoader";
 import Footer from "../components/Footer";
+import ThemeScript from "../components/ThemeScript";
 import { SiteConfigProvider } from "../contexts/SiteConfigContext";
 import { CookieConsentProvider } from "../contexts/CookieConsentContext";
 import { ThemeProvider } from "../contexts/ThemeContext";
@@ -22,13 +23,16 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className="antialiased bg-white text-gray-900 dark:bg-black dark:text-gray-100">
+      <head>
+        <ThemeScript />
+      </head>
+      <body className="antialiased">
         <ThemeProvider>
           <SiteConfigProvider>
             <CookieConsentProvider>
               <div className="flex flex-col min-h-screen">
                 <Navbar />
-                <main className="flex-grow bg-gray-50 dark:bg-gray-900 py-8">
+                <main className="flex-grow py-8">
                   <AnalyticsRouteChangeTracker />
                   <GoogleAnalyticsLoader />
                   {children}

--- a/components/ThemeScript.tsx
+++ b/components/ThemeScript.tsx
@@ -1,0 +1,24 @@
+"use client";
+import React from "react";
+import { themes } from "../utils/themes";
+
+const ThemeScript: React.FC = () => {
+  const code = `(() => {
+    try {
+      const stored = localStorage.getItem('theme') as Theme | null;
+      const theme = stored || (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
+      const colors = ${JSON.stringify(themes)}[theme];
+      const root = document.documentElement;
+      root.style.setProperty('--background', colors.background);
+      root.style.setProperty('--foreground', colors.foreground);
+      if (theme === 'dark') {
+        root.classList.add('dark');
+      } else {
+        root.classList.remove('dark');
+      }
+    } catch (e) {}
+  })()`;
+  return <script dangerouslySetInnerHTML={{ __html: code }} />;
+};
+
+export default ThemeScript;

--- a/contexts/ThemeContext.tsx
+++ b/contexts/ThemeContext.tsx
@@ -1,7 +1,6 @@
 "use client";
 import React, { createContext, useContext, useEffect, useState } from "react";
-
-type Theme = "light" | "dark";
+import { applyThemeColors, Theme } from "../utils/themes";
 
 interface ThemeContextType {
   theme: Theme;
@@ -17,19 +16,19 @@ export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ childre
     const stored = localStorage.getItem("theme") as Theme | null;
     if (stored) {
       setTheme(stored);
-      document.documentElement.classList.toggle("dark", stored === "dark");
+      applyThemeColors(stored);
       return;
     }
 
     const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
     const systemPref: Theme = mediaQuery.matches ? "dark" : "light";
     setTheme(systemPref);
-    document.documentElement.classList.toggle("dark", systemPref === "dark");
+    applyThemeColors(systemPref);
 
     const handleChange = (e: MediaQueryListEvent) => {
       const newTheme: Theme = e.matches ? "dark" : "light";
       setTheme(newTheme);
-      document.documentElement.classList.toggle("dark", newTheme === "dark");
+      applyThemeColors(newTheme);
     };
 
     mediaQuery.addEventListener("change", handleChange);
@@ -40,7 +39,7 @@ export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ childre
     const next = theme === "dark" ? "light" : "dark";
     setTheme(next);
     localStorage.setItem("theme", next);
-    document.documentElement.classList.toggle("dark", next === "dark");
+    applyThemeColors(next);
   };
 
   return (

--- a/utils/themes.ts
+++ b/utils/themes.ts
@@ -1,0 +1,20 @@
+export type Theme = 'light' | 'dark';
+
+export const themes: Record<Theme, { background: string; foreground: string }> = {
+  light: {
+    background: '#ffffff',
+    foreground: '#171717',
+  },
+  dark: {
+    background: '#1a1a1a',
+    foreground: '#f5f5f5',
+  },
+};
+
+export const applyThemeColors = (theme: Theme) => {
+  const colors = themes[theme];
+  const root = document.documentElement;
+  root.style.setProperty('--background', colors.background);
+  root.style.setProperty('--foreground', colors.foreground);
+  root.classList.toggle('dark', theme === 'dark');
+};


### PR DESCRIPTION
## Summary
- centralize theme color definitions
- apply theme colors early via inline script
- use CSS variables in ThemeProvider
- clean up layout theme handling

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68541597fb2c83319f773d9849e52f09