### PR TITLE
Add policy links to footer

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -9,11 +9,12 @@ const Footer: React.FC = () => {
   return (
     <footer className="bg-primary-800 text-primary-100 text-center p-6 shadow-inner">
       <p>&copy; {new Date().getFullYear()} React Markdown Blog. All rights reserved.</p>
+      <p className="text-sm mt-1">Powered by React, Tailwind CSS, and your Markdown!</p>
       <p className="text-sm mt-1">
-        Powered by React, Tailwind CSS, and your Markdown!{' '}
         <Link href="/page/privacy-policy" className="underline hover:text-primary-300">
           Informativa Privacy
-        </Link>{' | '}
+        </Link>
+        {' | '}
         <Link href="/page/cookie-policy" className="underline hover:text-primary-300 ml-1">
           Cookie Policy
         </Link>

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -33,8 +33,6 @@ const Navbar: React.FC = () => {
     { to: "/", text: "Home" },
     { to: "/tags", text: "Tags" },
     { to: "/page/about", text: "About" },
-    { to: "/page/privacy-policy", text: "Informativa Privacy" },
-    { to: "/page/cookie-policy", text: "Cookie Policy" },
   ];
 
   const displayTitle = isConfigLoading ? "Loading..." : (configError ? "Blog" : config.blogTitle);


### PR DESCRIPTION
## Summary
- display privacy and cookie policy links directly in the footer

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68542c2aa1948331a0c5fafb1f1ee28b